### PR TITLE
Fix scrollToLastItem function

### DIFF
--- a/hkm/static/hkm/js/hkm-v2.js
+++ b/hkm/static/hkm/js/hkm-v2.js
@@ -164,9 +164,9 @@ palikka
 
   function scrollToLastItem() {
 
-    var itemId = localStorage.getItem("last_record_browsed") || "";
-    if(itemId.length) {
-      var $item = $("[name="+itemId+"]");
+    var itemId = localStorage.getItem("last_record_browsed") || "_";
+    var $item = $("[name="+itemId+"]");
+    if($item.length) {
 
       $('html, body').animate({
         scrollTop: $item.offset().top


### PR DESCRIPTION
Instead of checking for last_record_browsed value check that $item element exists.