### PR TITLE
Show photo's era instead of exact year.

### DIFF
--- a/hkm/templates/hkm/base_viewer.html
+++ b/hkm/templates/hkm/base_viewer.html
@@ -116,7 +116,7 @@
           <p class="record-meta__paragraph">{{ record.rawData.description }}</p>
            <h2 class="record-meta__sub-header">{% trans 'Creation information' %}</h2>
           <p class="record-meta__paragraph">{% trans 'Photographer:' %} {% for photographer in record.rawData.photographer_str_mv %}{{ photographer }}, {% endfor %}</p>
-          <p class="record-meta__paragraph">{% trans 'Image pick-up year:' %} {{ record.year }}</p>
+          <p class="record-meta__paragraph">{% trans 'Image pick-up year:' %} {{ record.rawData.era.0|default:record.year }}</p>
 
           <h2 class="record-meta__sub-header">{% trans 'Property information' %}</h2>
           <p class="record-meta__paragraph">{% trans 'Measurements:' %} {% for measure in record.rawData.measurements %}{{ measure }}, {% endfor %}</p>


### PR DESCRIPTION
Based on users feedback exact year may be misleading.
Use "era" value instead.