### PR TITLE
Fix default value of photos year.

### DIFF
--- a/hkm/templates/hkm/base_viewer.html
+++ b/hkm/templates/hkm/base_viewer.html
@@ -116,7 +116,7 @@
           <p class="record-meta__paragraph">{{ record.rawData.description }}</p>
            <h2 class="record-meta__sub-header">{% trans 'Creation information' %}</h2>
           <p class="record-meta__paragraph">{% trans 'Photographer:' %} {% for photographer in record.rawData.photographer_str_mv %}{{ photographer }}, {% endfor %}</p>
-          <p class="record-meta__paragraph">{% trans 'Image pick-up year:' %} {{ record.rawData.era.0|default:record.year }}</p>
+          <p class="record-meta__paragraph">{% trans 'Image pick-up year:' %} {{ record.rawData.era.0|default:"" }}</p>
 
           <h2 class="record-meta__sub-header">{% trans 'Property information' %}</h2>
           <p class="record-meta__paragraph">{% trans 'Measurements:' %} {% for measure in record.rawData.measurements %}{{ measure }}, {% endfor %}</p>


### PR DESCRIPTION
Seems like api does not always have photos era OR year, for example https://hkm.finna.fi/Record/hkm.HKMS000005:0000000f
So default to empty string if era is not available.