### PR TITLE
Add check for loading button in case of no results

### DIFF
--- a/hkm/static/hkm/js/hkm-v2.js
+++ b/hkm/static/hkm/js/hkm-v2.js
@@ -181,30 +181,48 @@ palikka
     fetchingMoreImages = true;
     var page = parseInt($(this).data("current-page")) || 0;
     ajaxGetPageImages(page+1);
+    // if ( !$(this).has('.icon-spinner') ) {
+    //   $(this).append($('<i class="icon-spinner"></i>'));
+    // }
     $(this).append($('<i class="icon-spinner"></i>'));
   });
 
   function ajaxGetPageImages(page) {
     $.get({
       url: '',
-      data: 'loadallpages=0&page=' + page
-    })
-    .done(function(data) {
-      var re = /([^&=]+)=([^&]*)/g, m;
-
-      while (m = re.exec(queryString)) {
-        queryParameters[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
+      data: 'loadallpages=0&page=' + page,
+      success: function(data) {
+        var re = /([^&=]+)=([^&]*)/g, m;
+        while (m = re.exec(queryString)) {
+          queryParameters[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
+        }
+        queryParameters['page'] = page;
+  
+        window.history.replaceState("", "", "?"+$.param(queryParameters));
+        $container.append(data);
+        $container.imagesLoaded().progress(onProgress);
+        imageCount = $container.find('img').length;
+        loadedImageCount = 0;
+        fetchingMoreImages = false;
+        loadMoreButton.find('.icon-spinner').remove();
+        loadMoreButton.data({'current-page': page})
       }
-      queryParameters['page'] = page;
+    })
+    .fail(function() {
+      loadMoreButton.addClass('disabled').find('.icon-spinner').remove();
+      var buttonText = loadMoreButton.text();
 
-      window.history.replaceState("", "", "?"+$.param(queryParameters));
-      $container.append(data);
-      $container.imagesLoaded().progress(onProgress);
-      imageCount = $container.find('img').length;
-      loadedImageCount = 0;
-      fetchingMoreImages = false;
-      loadMoreButton.find('.icon-spinner').remove();
-      loadMoreButton.data({'current-page': page})
+      if (buttonText === "Lataa lisää... ") {
+        loadMoreButton.text('Ei tuloksia');
+      }
+
+      else if (buttonText === "Load more...") {
+        loadMoreButton.text('No more results');
+      } 
+
+      else {
+        loadMoreButton.text('Inga fler resultat');
+      }
     });
   }
 


### PR DESCRIPTION
Currently, the load more button hangs on loading if there are no more results or if there is a server error. This is a quick fix meant to show feedback when there aren't any new search results received from Finna.

Todo: Improve error handling and language checking.