### PR TITLE
Remove size parameters from Finna image requests

### DIFF
--- a/hkm/finna.py
+++ b/hkm/finna.py
@@ -150,13 +150,8 @@ class FinnaClient(object):
                   'data': {'result_data': repr(result_data)}})
         return result_data
 
-    def get_image_url(self, record_id, w=0, h=0):
-        if w != 0 and h != 0:
-            url = 'https://finna.fi/Cover/Show?id=%s&w=%d&h=%d' % (
-                record_id, w, h)
-        else:
-            url = 'https://finna.fi/Cover/Show?id=%s&fullres=1&index=0' % record_id
-        return url
+    def get_image_url(self, record_id):
+        return 'https://finna.fi/Cover/Show?id=%s&fullres=1&index=0' % record_id
 
     def download_image(self, record_id):
         r = requests.get(self.get_image_url(record_id), stream=True)

--- a/hkm/templates/hkm/snippets/search_records_grid.html
+++ b/hkm/templates/hkm/snippets/search_records_grid.html
@@ -19,7 +19,7 @@
           </i>
         </div>
       {% endif %}
-      <img class="flex-img" src="{% finna_image record.id w=400 h=400 %}"></img>
+      <img class="flex-img" src="{% finna_image record.id %}"></img>
     </a>
     <div class="grid__meta">
       <span class="grid__meta--title">{{ record.title }}</span>

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -17,8 +17,8 @@ register = template.Library()
 
 
 @register.simple_tag
-def finna_image(img_id, w=0, h=0):
-    return FINNA.get_image_url(img_id, w=w, h=h)
+def finna_image(img_id):
+    return finna_default_image_url(img_id)
 
 
 @register.filter


### PR DESCRIPTION
Finna does not support providing the size parameters `w` and `h` anymore when fetching images. Remove the size parameters from the request.