### PR TITLE
HEL-18 | Change default admin username

### DIFF
--- a/.prod/on_deploy.sh
+++ b/.prod/on_deploy.sh
@@ -8,9 +8,9 @@ python /app/manage.py migrate --noinput
 # If no password is set, the admin user gets a generated password which will
 # be written in stdout so that it can be accessed during the initial deployment.
 if [[ "$ADMIN_USER_PASSWORD" ]]; then
-    python /app/manage.py add_admin_user -u admin -p $ADMIN_USER_PASSWORD -e admin@example.com
+    python /app/manage.py add_admin_user -u kuva-admin -p $ADMIN_USER_PASSWORD -e kuva-admin@hel.ninja
 else
-    python /app/manage.py add_admin_user -u admin -e admin@example.com
+    python /app/manage.py add_admin_user -u kuva-admin -e kuva-admin@hel.ninja
 fi
 
 python /app/manage.py create_initial_page_content

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Prerequisites:
    * Set entrypoint/startup variables according to taste.
      * `DEBUG`, controls debug mode on/off 
      * `APPLY_MIGRATIONS`, applies migrations on startup
-     * `CREATE_ADMIN_USER`, creates an admin user with credentials `admin`:(password, see below)
-     (admin@example.com)
+     * `CREATE_ADMIN_USER`, creates an admin user with credentials `kuva-admin`:(password, see below)
+     (kuva-admin@hel.ninja)
      * `ADMIN_USER_PASSWORD`, the admin user's password. If this is not given, a random password is generated
      and written into stdout when an admin user is created automatically.
      * `ADD_INITIAL_CONTENT`, bootstrap data import for divisions

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,9 +18,9 @@ fi
 # Create admin user. Generate password if there isn't one in the environment variables
 if [[ "$CREATE_ADMIN_USER" = "1" ]]; then
     if [[ "$ADMIN_USER_PASSWORD" ]]; then
-      ./manage.py add_admin_user -u admin -p $ADMIN_USER_PASSWORD -e admin@example.com
+      ./manage.py add_admin_user -u kuva-admin -p $ADMIN_USER_PASSWORD -e kuva-admin@hel.ninja
     else
-      ./manage.py add_admin_user -u admin -e admin@example.com
+      ./manage.py add_admin_user -u kuva-admin -e kuva-admin@hel.ninja
     fi
 fi
 

--- a/hkm/management/commands/add_admin_user.py
+++ b/hkm/management/commands/add_admin_user.py
@@ -10,13 +10,13 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "-u", "--username", type=str, help="Username", default="admin"
+            "-u", "--username", type=str, help="Username", default="kuva-admin"
         )
         parser.add_argument(
             "-p", "--password", type=str, help="Password", default=""
         )
         parser.add_argument(
-            "-e", "--email", type=str, help="Email", default="admin@example.com"
+            "-e", "--email", type=str, help="Email", default="kuva-admin@hel.ninja"
         )
 
     def handle(self, *args, **kwargs):


### PR DESCRIPTION
Changed the default admin username to kuva-admin so that if/when the
database is initialized with the existing data dump from the old site,
our init scripts will create a separate superuser that we can use.