### PR TITLE
HEL-27 | Add Mailgun configuration to the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ staticroot/*
 components/*
 docker-compose.env.yaml
 .idea
+/venv/
+media/*
+static/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,11 @@ review:
         K8S_SECRET_DEBUG: 1
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
         K8S_SECRET_HKM_FEEDBACK_FROM_EMAIL: "no-reply@hel.ninja"
+        K8S_SECRET_HKM_FEEDBACK_NOTIFICATION_EMAILS: "dummy-address@hel.ninja"
+        K8S_SECRET_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
+        K8S_SECRET_MAIL_MAILGUN_KEY: "$GL_MAILGUN_API_KEY"
+        K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
+        K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"
         K8S_SECRET_HKM_PBW_API_ENDPOINT: "https://dev-payform.bambora.com/pbwapi"
         K8S_SECRET_HKM_PBW_API_KEY: "$GL_QA_PBW_API_KEY"
         K8S_SECRET_HKM_PBW_SECRET_KEY: "$GL_QA_PBW_SECRET_KEY"
@@ -24,6 +29,7 @@ review:
         K8S_SECRET_HKM_PRINTMOTOR_PASSWORD: "$GL_QA_PRINTMOTOR_PASSWORD"
         K8S_SECRET_HKM_PRINTMOTOR_API_KEY: "$GL_QA_PRINTMOTOR_API_KEY"
         K8S_SECRET_HKM_PRINTMOTOR_API_ENDPOINT: "https://test.printmotor.io/api/v1/order"
+
 
 staging:
     only:
@@ -36,6 +42,11 @@ staging:
         K8S_SECRET_SECRET_KEY: "$GL_QA_DJANGO_SECRET_KEY"
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
         K8S_SECRET_HKM_FEEDBACK_FROM_EMAIL: "no-reply@hel.ninja"
+        K8S_SECRET_HKM_FEEDBACK_NOTIFICATION_EMAILS: "dummy-address@hel.ninja"
+        K8S_SECRET_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
+        K8S_SECRET_MAIL_MAILGUN_KEY: "$GL_MAILGUN_API_KEY"
+        K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
+        K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"
         K8S_SECRET_HKM_PBW_API_ENDPOINT: "https://dev-payform.bambora.com/pbwapi"
         K8S_SECRET_HKM_PBW_API_KEY: "$GL_QA_PBW_API_KEY"
         K8S_SECRET_HKM_PBW_SECRET_KEY: "$GL_QA_PBW_SECRET_KEY"
@@ -53,6 +64,12 @@ production:
         K8S_SECRET_SECRET_KEY: "$GL_STABLE_DJANGO_SECRET_KEY"
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
         K8S_SECRET_HKM_FEEDBACK_FROM_EMAIL: "no-reply@hel.fi"
+        # TODO: Configure production feedback recipient
+        K8S_SECRET_HKM_FEEDBACK_NOTIFICATION_EMAILS: "dummy-address@hel.ninja"
+        K8S_SECRET_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
+        K8S_SECRET_MAIL_MAILGUN_KEY: "$GL_MAILGUN_API_KEY"
+        K8S_SECRET_MAIL_MAILGUN_DOMAIN: "mail.hel.ninja"
+        K8S_SECRET_MAIL_MAILGUN_API: "https://api.eu.mailgun.net/v3"
         # TODO: Configure production PayByWay
         K8S_SECRET_HKM_PBW_API_ENDPOINT: ""
         K8S_SECRET_HKM_PBW_API_KEY: "$GL_STABLE_PBW_API_KEY"

--- a/docker-compose.env.example.yaml
+++ b/docker-compose.env.example.yaml
@@ -27,3 +27,18 @@ HKM_PRINTMOTOR_PASSWORD=
 HKM_PRINTMOTOR_API_KEY=
 # Printmotor service endpoint
 HKM_PRINTMOTOR_API_ENDPOINT=
+
+# The "from" address when the app sends emails
+HKM_FEEDBACK_FROM_EMAIL=no-reply@hel.ninja
+
+# Comma-separated list of email addresses where the app will send feedback
+HKM_FEEDBACK_NOTIFICATION_EMAILS=dummy-address@hel.ninja
+
+# Uncomment this if you want to send emails using Mailgun. The app defaults to
+# console logging otherwise.
+#EMAIL_BACKEND=anymail.backends.mailgun.EmailBackend
+
+# Mailgun configuration (fill these if you want to actually send emails)
+MAIL_MAILGUN_KEY=
+MAIL_MAILGUN_DOMAIN=
+MAIL_MAILGUN_API=

--- a/kuvaselaamo/settings.py
+++ b/kuvaselaamo/settings.py
@@ -10,6 +10,9 @@ env = environ.Env(
     ALLOWED_HOSTS=(list, []),
     DATABASE_URL=(str, ''),
     EMAIL_BACKEND=(str, 'django.core.mail.backends.console.EmailBackend'),
+    MAIL_MAILGUN_KEY=(str, ""),
+    MAIL_MAILGUN_DOMAIN=(str, ""),
+    MAIL_MAILGUN_API=(str, ""),
     HKM_FEEDBACK_FROM_EMAIL=(str, 'system@localhost'),
     HKM_FEEDBACK_NOTIFICATION_EMAILS=(list, ['dummy.address@hel.ninja']),
     HKM_PBW_API_ENDPOINT = (str, ''),
@@ -32,6 +35,12 @@ if DEBUG and not SECRET_KEY:
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 
 EMAIL_BACKEND=env.str('EMAIL_BACKEND')
+if env("MAIL_MAILGUN_KEY"):
+    ANYMAIL = {
+        "MAILGUN_API_KEY": env("MAIL_MAILGUN_KEY"),
+        "MAILGUN_SENDER_DOMAIN": env("MAIL_MAILGUN_DOMAIN"),
+        "MAILGUN_API_URL": env("MAIL_MAILGUN_API"),
+    }
 
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -152,7 +161,7 @@ INSTALLED_APPS = (
 
     'django.contrib.admin.apps.SimpleAdminConfig',
 
-    #'utils',
+    'anymail'
 )
 
 # Bower

--- a/requirements.in
+++ b/requirements.in
@@ -49,3 +49,4 @@ supervisor
 watchdog
 django-parler
 django-bower
+django-anymail~=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ cffi==1.10.0              # via -r requirements.in, bcrypt, cryptography, pynacl
 contextlib2==0.5.4        # via raven
 coverage==4.3.4           # via -r requirements.in
 cryptography==2.8         # via -r requirements.in, paramiko, pyopenssl
+django-anymail==3.0       # via -r requirements.in
 django-appconf==1.0.2     # via -r requirements.in, django-compressor
 django-apptemplates==1.2  # via -r requirements.in
 django-bower==5.2.0       # via -r requirements.in
@@ -27,7 +28,7 @@ django-phonenumber-field==1.3.0  # via -r requirements.in
 django-redis-sessions==0.5.6  # via -r requirements.in
 django-supervisor==0.4.0  # via -r requirements.in
 django-widget-tweaks==1.4.1  # via -r requirements.in
-django==1.10.8            # via -r requirements.in, django-bower, django-phonenumber-field
+django==1.10.8            # via -r requirements.in, django-anymail, django-bower, django-phonenumber-field
 djangorestframework==3.6.2  # via -r requirements.in
 enum34==1.1.6             # via -r requirements.in, cryptography, pyscss
 factory-boy==2.12.0       # via -r requirements.in
@@ -62,8 +63,8 @@ pyyaml==3.12              # via -r requirements.in, watchdog
 raven==6.0.0              # via -r requirements.in
 rcssmin==1.0.6            # via django-compressor
 redis==2.10.5             # via django-redis-sessions
-requests==2.13.0          # via -r requirements.in
+requests==2.13.0          # via -r requirements.in, django-anymail
 rjsmin==1.1.0             # via django-compressor
-six==1.10.0               # via -r requirements.in, bcrypt, cryptography, django-bower, django-extensions, faker, mock, pynacl, pyopenssl, pyscss, python-dateutil, python-memcached
+six==1.10.0               # via -r requirements.in, bcrypt, cryptography, django-anymail, django-bower, django-extensions, faker, mock, pynacl, pyopenssl, pyscss, python-dateutil, python-memcached
 supervisor==3.3.1         # via -r requirements.in, django-supervisor
 watchdog==0.8.3           # via -r requirements.in, django-supervisor


### PR DESCRIPTION
Added the necessary things in order to get email sending to work using XO's Mailgun service:
- Added django-anymail to the application (had to use an ancient version to
avoid having to change the current Django version)
- Updated the requirements
- Added suitable environment variables to settings
- Added examples of the environment variables to docker config
- Added the environment variables to the Gitlab configs.