### PR TITLE
HEL-52 | Fix image permanent link

### DIFF
--- a/hkm/forms.py
+++ b/hkm/forms.py
@@ -20,7 +20,7 @@ class CollectionForm(forms.ModelForm):
         super(CollectionForm, self).__init__(*args, **kwargs)
         if not self.user.is_authenticated() or not self.user.profile.is_admin:
             del self.fields['show_in_landing_page']
-            del self.fields['is_fea tured']
+            del self.fields['is_featured']
 
     class Meta:
         model = Collection

--- a/hkm/forms.py
+++ b/hkm/forms.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ValidationError
 
 from hkm.models.campaigns import CampaignCode
-from hkm.models.models import Collection, Feedback, ProductOrder, ProductOrderCollection, Showcase, UserProfile
+from hkm.models.models import Collection, Feedback, ProductOrder, ProductOrderCollection, Showcase
 
 LOG = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class CollectionForm(forms.ModelForm):
         super(CollectionForm, self).__init__(*args, **kwargs)
         if not self.user.is_authenticated() or not self.user.profile.is_admin:
             del self.fields['show_in_landing_page']
-            del self.fields['is_featured']
+            del self.fields['is_fea tured']
 
     class Meta:
         model = Collection
@@ -73,7 +73,8 @@ class RegistrationForm(UserCreationForm):
 
 class ProductOrderCollectionForm(forms.ModelForm):
     action = forms.CharField(widget=forms.HiddenInput(attrs={'value': 'checkout'}))
-    orderer_name = forms.CharField(required=False, widget=forms.TextInput(attrs={'class': 'form-control'}), label=_(u"Orderer's name"))
+    orderer_name = forms.CharField(required=False, widget=forms.TextInput(attrs={'class': 'form-control'}),
+                                   label=_(u"Orderer's name"))
 
     class Meta:
         model = ProductOrderCollection
@@ -119,7 +120,7 @@ class ShowcaseForm(forms.ModelForm):
         fields = ['title', 'albums', 'show_on_home_page']
 
     def __init__(self, *args, **kwargs):
-        super(ShowcaseForm, self).__init__(*args, **kwargs)       
+        super(ShowcaseForm, self).__init__(*args, **kwargs)
         self.fields['albums'].queryset = Collection.objects.filter(owner__profile__is_museum=True)
 
     def clean(self):

--- a/hkm/templates/hkm/snippets/search_records_grid.html
+++ b/hkm/templates/hkm/snippets/search_records_grid.html
@@ -9,7 +9,7 @@
           <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-shopping"></use>
         </svg>
     </a>
-    <a href="{% url 'hkm_search_record' %}?search={{ search_term }}{% for facet in author_facets %}&author[]={{ facet }}{% endfor %}{% for facet in date_facets %}&main_date_str[]={{ facet }}{% endfor %}&page={{ record.index }}">
+    <a href="{% url 'hkm_search_record' %}?image_id={{ record.id }}">
       {% if user.is_authenticated %}
         <div class="grid__fav {% if record.is_favorite %}active{% endif %}" data-record-id="{{ record.id }}">
           <i class="grid__fav-icon">

--- a/hkm/templates/hkm/views/search_record.html
+++ b/hkm/templates/hkm/views/search_record.html
@@ -5,11 +5,11 @@
 {% block viewer_arrows %}
 
 
-  {% if search_result.previous_page %}
-    <a href="{% url 'hkm_search_record' %}?search={{ search_term }}{% for facet in author_facets %}&author[]={{ facet }}{% endfor %}{% for facet in date_facets %}&main_date_str[]={{ facet }}{% endfor %}&page={{ search_result.previous_page }}" class="image-viewer-arrow arrow-left"><img src="/static/hkm/img/arrow_left.png"></img></a>
+  {% if record|previous_image:search_result.records %}
+    <a href="{% url 'hkm_search_record' %}?image_id={{ record|previous_image:search_result.records }}" class="image-viewer-arrow arrow-left"><img src="/static/hkm/img/arrow_left.png"></img></a>
   {% endif %}
-  {% if search_result.next_page %}
-    <a href="{% url 'hkm_search_record' %}?search={{ search_term }}{% for facet in author_facets %}&author[]={{ facet }}{% endfor %}{% for facet in date_facets %}&main_date_str[]={{ facet }}{% endfor %}&page={{ search_result.next_page }}" class="image-viewer-arrow arrow-right"><img src="/static/hkm/img/arrow_right.png"></img></a>
+  {% if record|next_image:search_result.records %}
+    <a href="{% url 'hkm_search_record' %}?image_id={{ record|next_image:search_result.records }}" class="image-viewer-arrow arrow-right"><img src="/static/hkm/img/arrow_right.png"></img></a>
   {% endif %}
 
 {% endblock %}

--- a/hkm/templates/hkm/views/search_record.html
+++ b/hkm/templates/hkm/views/search_record.html
@@ -4,19 +4,22 @@
 
 {% block viewer_arrows %}
 
+  {% if search_result %}
+    {% if previous_record %}
+      <a href="{% url 'hkm_search_record' %}?image_id={{ previous_record.id }}" class="image-viewer-arrow arrow-left"><img src="/static/hkm/img/arrow_left.png"></img></a>
+    {% endif %}
 
-  {% if record|previous_image:search_result.records %}
-    <a href="{% url 'hkm_search_record' %}?image_id={{ record|previous_image:search_result.records }}" class="image-viewer-arrow arrow-left"><img src="/static/hkm/img/arrow_left.png"></img></a>
-  {% endif %}
-  {% if record|next_image:search_result.records %}
-    <a href="{% url 'hkm_search_record' %}?image_id={{ record|next_image:search_result.records }}" class="image-viewer-arrow arrow-right"><img src="/static/hkm/img/arrow_right.png"></img></a>
-  {% endif %}
+    {% if next_record %}
+      <a href="{% url 'hkm_search_record' %}?image_id={{ next_record.id }}" class="image-viewer-arrow arrow-right"><img src="/static/hkm/img/arrow_right.png"></img></a>
+    {% endif %}
+
+  {% endif%}
 
 {% endblock %}
 
 {% block content %}
 
-  {% if record %}
+  {% if search_result %}
     {% if record.index %}
       <div class="back-to">
         <span class="back-to__title">{{ record.title }}</span><br>
@@ -39,8 +42,6 @@
       </div>
     </div>
 
-  {% else %}
-    {% include 'hkm/snippets/not_responding.html' %}
   {% endif %}
 {% endblock %}
   

--- a/hkm/templates/hkm/views/search_record.html
+++ b/hkm/templates/hkm/views/search_record.html
@@ -17,24 +17,28 @@
 {% block content %}
 
   {% if record %}
-    <div class="back-to">
-      <span class="back-to__title">{{ record.title }}</span><br>
-      <span>{% trans 'Search' %}: {{ search_term }} ({{ record.index }}/{{search_result.resultCount}})</span><br>
-      <a href="{% url 'hkm_search' %}?search={{search_term}}&page={{ search_result_page }}">
-        <i class="back-to__icon">
-          <svg class="svg-icon">
-            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left"></use>
-          </svg>
-        </i>
-        <span class="back-to__text">{% trans 'Back to search' %}</span>
-      </a>
-    </div>
+    {% if record.index %}
+      <div class="back-to">
+        <span class="back-to__title">{{ record.title }}</span><br>
+        <span>{% trans 'Search' %}: {{ search_term }} ({{ record.index }}/{{search_result.resultCount}})</span><br>
+        <a href="{% url 'hkm_search' %}?search={{search_term}}&page={{ current_page }}{% for facet in author_facets %}&author[]={{ facet }}{% endfor %}{% for facet in date_facets %}&main_date_str[]={{ facet }}{% endfor %}">
+          <i class="back-to__icon">
+            <svg class="svg-icon">
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left"></use>
+            </svg>
+          </i>
+          <span class="back-to__text">{% trans 'Back to search' %}</span>
+        </a>
+      </div>
+    {% endif%}
+
 
     <div title="{% trans 'Left and right click to zoom.' %}" class="image-viewer">
       <div id="zoomable-image-container" class="image-viewer__container">
         <img id="zoomable-image" class="image-viewer__image" data-full-res-url="{{ record.full_res_url }}" src="{% finna_image record.id %}"></img>
       </div>
     </div>
+
   {% else %}
     {% include 'hkm/snippets/not_responding.html' %}
   {% endif %}

--- a/hkm/templates/hkm/views/search_record.html
+++ b/hkm/templates/hkm/views/search_record.html
@@ -19,7 +19,7 @@
   {% if record %}
     <div class="back-to">
       <span class="back-to__title">{{ record.title }}</span><br>
-      <span>{% trans 'Search' %}: {{ search_term }} ({{ current_page }}/{{search_result.resultCount}})</span><br>
+      <span>{% trans 'Search' %}: {{ search_term }} ({{ record.index }}/{{search_result.resultCount}})</span><br>
       <a href="{% url 'hkm_search' %}?search={{search_term}}&page={{ search_result_page }}">
         <i class="back-to__icon">
           <svg class="svg-icon">

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -76,16 +76,7 @@ def showcase_collections(showcase):
 
 @register.filter
 def previous_image(record, records=None):
-    previous_id = ""
-
-    # Or should this only be a check that if records[0][index] < record[index]
-    if records is not None and record.get('index'):
-        for r in records:
-            if r['index'] < record['index']:
-                previous_id = r['id']
-                break
-
-    return previous_id
+    return records[0]['id'] if len(records) > 1 and record.get('index') > records[0].get('index') else ""
 
 @register.filter
 def next_image(record, records=None):

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -73,3 +73,22 @@ def front_page_url(collection):
 def showcase_collections(showcase):
     albums = showcase.albums.all().order_by('created')
     return albums
+
+@register.filter
+def previous_image(record, records=None):
+    # If image index in array is 1, it has previous image
+    previous_id = ""
+    image_index = records.index(record)
+    if image_index == 1:
+        previous_id = records[0]['id']
+    print('PREVIOUS ID', previous_id)
+    return previous_id
+
+@register.filter
+def next_image(record, records=None):
+    next_id = ""
+    image_index = records.index(record)
+    print('record1', records[0])
+    if image_index == 1 and len(records) == 3:
+        next_id = records[2]['id']
+    return next_id

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -76,19 +76,24 @@ def showcase_collections(showcase):
 
 @register.filter
 def previous_image(record, records=None):
-    # If image index in array is 1, it has previous image
     previous_id = ""
-    image_index = records.index(record)
-    if image_index == 1:
-        previous_id = records[0]['id']
-    print('PREVIOUS ID', previous_id)
+
+    # Or should this only be a check that if records[0][index] < record[index]
+    if records is not None and record.get('index'):
+        for r in records:
+            if r['index'] < record['index']:
+                previous_id = r['id']
+                break
+
     return previous_id
 
 @register.filter
 def next_image(record, records=None):
     next_id = ""
-    image_index = records.index(record)
-    print('record1', records[0])
-    if image_index == 1 and len(records) == 3:
-        next_id = records[2]['id']
+
+    if records is not None and record.get('index'):
+        for r in records:
+            if r['index'] > record['index']:
+                next_id = r['id']
+
     return next_id

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -73,18 +73,3 @@ def front_page_url(collection):
 def showcase_collections(showcase):
     albums = showcase.albums.all().order_by('created')
     return albums
-
-@register.filter
-def previous_image(record, records=None):
-    return records[0]['id'] if len(records) > 1 and record.get('index') > records[0].get('index') else ""
-
-@register.filter
-def next_image(record, records=None):
-    next_id = ""
-
-    if records is not None and record.get('index'):
-        for r in records:
-            if r['index'] > record['index']:
-                next_id = r['id']
-
-    return next_id

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -559,7 +559,7 @@ class SearchView(BaseView):
                     self.record = result.get('records')[0] if result else None
                 # If user came from list view, get selected image from session
                 else:
-                    # Form 3 record array, previous - selected - next
+                    # Save previous - selected - next records to corresponding variables
                     record_index = record.get('index')
                     if record_index > 1:
                         self.previous_record = records[record_index - 2]

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -502,8 +502,8 @@ class SearchView(BaseView):
             return self.template_name
 
     def setup(self, request, *args, **kwargs):
-        # Session expires after one(1) minute
-        request.session.set_expiry(60 * 5)
+        # Session expires after one(1) hour
+        request.session.set_expiry(60 * 60)
         self.search_term = request.GET.get('search', '')
         self.author_facets = filter(
             None, request.GET.getlist('author[]', None))


### PR DESCRIPTION
Search results are now saved in session. If link is copied from address bar and no session is found, image is fetched from finna based on `image_id` parameter. In this case previous and next arrows + "Back to search results" button is hidden.

"Image detail view" allows user to move to previous and next image. This view uses images found in session and does not fetch more if last image is reached (this is logic might be improved later).

Also cleaned up some unused imports.