### PR TITLE
Add accessibility statement page link to footer

### DIFF
--- a/hkm/templates/hkm/base.html
+++ b/hkm/templates/hkm/base.html
@@ -110,6 +110,7 @@
           <a href="{% url 'hkm_siteinfo_QA' %}"><p>{% trans 'Frequently asked questions' %}</p></a>
           <a href="{% url 'hkm_siteinfo_terms' %}"><p>{% trans 'Terms of use' %}</p></a>
           <a href="{% url 'hkm_siteinfo_privacy' %}"><p>{% trans 'Privacy policy' %}</p></a>
+          <a href="{% url 'hkm_siteinfo_accessibility' %}"><p>{% trans 'Accessibility statement' %}</p></a>
           <p><a href="{% url 'hkm_info' %}">{% trans 'Feedback' %}</a></p>
         </div>
         <div class="col-sm-4">

--- a/kuvaselaamo/locale/en/LC_MESSAGES/django.po
+++ b/kuvaselaamo/locale/en/LC_MESSAGES/django.po
@@ -485,6 +485,9 @@ msgstr "Terms of use"
 msgid "Privacy policy"
 msgstr "Privacy and register details"
 
+msgid "Accessibility statement"
+msgstr "Accessibility statement"
+
 #: hkm/templates/hkm/base.html:113
 #: hkm/templates/hkm/snippets/navigation.html:35
 #: hkm/templates/hkm/views/info.html:9

--- a/kuvaselaamo/locale/fi/LC_MESSAGES/django.po
+++ b/kuvaselaamo/locale/fi/LC_MESSAGES/django.po
@@ -466,6 +466,9 @@ msgstr "Käyttöehdot"
 msgid "Privacy policy"
 msgstr "Tietosuoja"
 
+msgid "Accessibility statement"
+msgstr "Saavutettavuusseloste"
+
 #: hkm/templates/hkm/base.html:113
 #: hkm/templates/hkm/snippets/navigation.html:35
 #: hkm/templates/hkm/views/info.html:9

--- a/kuvaselaamo/locale/sv/LC_MESSAGES/django.po
+++ b/kuvaselaamo/locale/sv/LC_MESSAGES/django.po
@@ -460,6 +460,9 @@ msgstr "Användningsvillkor"
 msgid "Privacy policy"
 msgstr "Dataskydd "
 
+msgid "Accessibility statement"
+msgstr "Tillgänglighetsutlåtande"
+
 #: hkm/templates/hkm/base.html:113
 #: hkm/templates/hkm/snippets/navigation.html:35
 #: hkm/templates/hkm/views/info.html:9


### PR DESCRIPTION
Adds accessibility statement link to footer. The page itself is already created in the helsinkikuvia with 'hkm_siteinfo_accessibility' identifier.