### PR TITLE
Add misssing url, view and template to accessibility page

### DIFF
--- a/hkm/templates/hkm/views/siteinfo_accessibility.html
+++ b/hkm/templates/hkm/views/siteinfo_accessibility.html
@@ -1,0 +1,20 @@
+{% extends 'hkm/base_browse.html' %}
+{% load i18n %}
+
+{% block banner %}
+
+  <div class="page-header">
+    <div class="fullsize-container container">
+      <div class="banner__title">
+        <h1 class="banner__h1 centered-fullwidth">{{ page_content.title|safe }}</h1>
+      </div>
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block content %}
+  <div class="container-small container">
+    {{ page_content.content|safe }}
+  </div>
+{% endblock %}

--- a/hkm/urls.py
+++ b/hkm/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     url(r'^info/$', views.InfoView.as_view(), name='hkm_info'),
 
     url(r'^about/$', views.SiteinfoAboutView.as_view(), name='hkm_siteinfo_about'),
+    url(r'^accessibility/$', views.SiteinfoAccessibilityView.as_view(), name='hkm_siteinfo_accessibility'),
     url(r'^privacy/$', views.SiteinfoPrivacyView.as_view(),
         name='hkm_siteinfo_privacy'),
     url(r'^QA/$', views.SiteinfoQAView.as_view(), name='hkm_siteinfo_QA'),

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -1256,7 +1256,7 @@ class SiteinfoAccessibilityView(TranslatableContentView):
     url_name = 'hkm_siteinfo_accessibility'
 
     def get(self, request, *args, **kwargs):
-        return super(SiteinfoAboutView, self).get(request, *args, **kwargs)
+        return super(SiteinfoAccessibilityView, self).get(request, *args, **kwargs)
 
 class SiteinfoPrivacyView(TranslatableContentView):
     template_name = 'hkm/views/siteinfo_privacy.html'

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -1251,6 +1251,12 @@ class SiteinfoAboutView(TranslatableContentView):
     def get(self, request, *args, **kwargs):
         return super(SiteinfoAboutView, self).get(request, *args, **kwargs)
 
+class SiteinfoAccessibilityView(TranslatableContentView):
+    template_name = 'hkm/views/siteinfo_accessibility.html'
+    url_name = 'hkm_siteinfo_accessibility'
+
+    def get(self, request, *args, **kwargs):
+        return super(SiteinfoAboutView, self).get(request, *args, **kwargs)
 
 class SiteinfoPrivacyView(TranslatableContentView):
     template_name = 'hkm/views/siteinfo_privacy.html'


### PR DESCRIPTION
Noticed that these were missing from the initial implementation. To accessibility page to work it needs the url and view. Template is not 100% necessary, but every other page has it so it's there.