### PR TITLE
HEL-127 | Change showcase owner display logic

### DIFF
--- a/hkm/templates/hkm/views/home_page.html
+++ b/hkm/templates/hkm/views/home_page.html
@@ -51,7 +51,7 @@
                           {{ collection.title }}
                         </span>
                         <span class="card-meta__owner">
-                          {% if collection.is_featured %}
+                          {% if collection.owner.is_staff %}
                             <img src="/static/hkm/svg/Kaupunginmuseo.svg" alt="museum" class="public-collections__svg">
                           {% else %}
                             <img src="/static/hkm/svg/Person.svg" alt="museum" class="public-collections__svg-person">

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -71,5 +71,5 @@ def front_page_url(collection):
 
 @register.filter
 def showcase_collections(showcase):
-    albums = showcase.albums.all().order_by('created')
+    albums = showcase.albums.select_related('owner').all().order_by('created')
     return albums

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -378,8 +378,14 @@ class HomeView(BaseView):
 
     def get_context_data(self, **kwargs):
         context = super(HomeView, self).get_context_data(**kwargs)
-        context['frontpage_image_collection'] = Collection.objects.filter(show_in_landing_page=True).order_by('created').first()
-        context['showcases'] = Showcase.objects.filter(show_on_home_page=True).order_by('-created')
+        context['frontpage_image_collection'] = Collection.objects.\
+            prefetch_related('records').\
+            filter(show_in_landing_page=True).\
+            order_by('created').first()
+        context['showcases'] = Showcase.objects.\
+            prefetch_related('albums').\
+            filter(show_on_home_page=True).\
+            order_by('-created')
         return context
 
 


### PR DESCRIPTION
Change the way the front page determines what is displayed as the owner of
a showcased collection. Earlier this used the is_featured flag of a Collection,
but the more logical solution is to do this automatically by checking if the
owner of the displayed Collection is a staff member or not. If they are staff,
the Helsinki logo is displayed. Otherwise the user icon + username.

I also added some prefetching in the queries to lessen the number of db
queries on the frontpage.