### PR TITLE
HEL-178 | Point full res image URL to proxy server in all record views

### DIFF
--- a/hkm/models/models.py
+++ b/hkm/models/models.py
@@ -207,32 +207,28 @@ class Record(OrderedModel, BaseModel):
         return data
 
     def get_full_res_image_absolute_url(self):
-        if self.edited_full_res_image:
-            return u'%s%s' % (settings.HKM_MY_DOMAIN, self.edited_full_res_image.url)
-        else:
-            record_data = self.get_details()
-            if record_data:
-                record_url = record_data['rawData']['thumbnail']
-                cache_key = '%s-record-preview-url' % record_url
-                full_res_url = DEFAULT_CACHE.get(cache_key, None)
-                if full_res_url == None:
-                    full_res_url = HKM.get_full_res_image_url(
-                        record_data['rawData']['thumbnail'])
-                    DEFAULT_CACHE.set(cache_key, full_res_url, 60 * 15)
-                else:
-                    LOG.debug('Got record full res url from cache', extra={
-                              'data': {'full_res_url': repr(full_res_url)}})
-                return full_res_url
+        record_data = self.get_details()
+        if record_data:
+            record_url = record_data['rawData']['thumbnail']
+            cache_key = '%s-record-preview-url' % record_url
+            full_res_url = DEFAULT_CACHE.get(cache_key, None)
+            if full_res_url is None:
+                full_res_url = HKM.get_full_res_image_url(
+                    record_data['rawData']['thumbnail'])
+                DEFAULT_CACHE.set(cache_key, full_res_url, 60 * 15)
             else:
-                LOG.debug('Could not get image from Finna API')
+                LOG.debug('Got record full res url from cache', extra={
+                          'data': {'full_res_url': repr(full_res_url)}})
+            return full_res_url
+        else:
+            LOG.debug('Could not get image from Finna API')
 
     def get_preview_image_absolute_url(self):
         LOG.debug('Getting web image absolute url', extra={
                   'data': {'finna_id': self.record_id}})
-        # if self.edited_preview_image:
-        #	return u'%s%s' % (settings.HKM_MY_DOMAIN, self.edited_preview_image.url)
-        # else:
+
         url = FINNA.get_image_url(self.record_id)
+
         LOG.debug('Got web image absolute url', extra={'data': {'url': url}})
         return url
 


### PR DESCRIPTION
## Description

When a user opens their own album's record, they will now get the same full
resolution image URL as the rest of the views. The URL points to the proxy
server which has larger resolution images than the ones which were used in
the own album view earlier.

## Context

[HEL-174](https://helsinkisolutionoffice.atlassian.net/browse/HEL-174)

## How Has This Been Tested?

Tested manually on the developer's environment.

## Manual Testing Instructions for Reviewers

1. Login as a user who has an own album with an image
2. Click "Own albums"
3. Select one of your albums
4. Select one of the images inside
5. Click on "Download full resolution image"
6. Verify that the link points to http://89.250.56.218/KDKDataProvider/(something) and that it returns an image.