### PR TITLE
HEL-207 | Fix favourite not updating after refresh

### DIFF
--- a/hkm/templates/hkm/base_viewer.html
+++ b/hkm/templates/hkm/base_viewer.html
@@ -45,15 +45,13 @@
                 </svg>
               </i>
             </button>
-          {% with web_image_url=record.id|finna_default_image_url %}
-          <button class="actions__btn actions__btn--right actions_crop" id="actions-add" tooltip-title="{% trans 'Add to collection' %}" data-img-url="{{ web_image_url }}" data-toggle="modal" data-record-id="{{ record.id }}" data-target="#crop-and-add">
+          <button class="actions__btn actions__btn--right actions_crop" id="actions-add" tooltip-title="{% trans 'Add to collection' %}" data-img-url="{{ record_web_url }}" data-toggle="modal" data-record-id="{{ record.id }}" data-target="#crop-and-add">
             <i class="actions__icon">
               <svg class="svg-icon">
                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-plus"></use>
               </svg>
             </i>
           </button>
-          {% endwith %}
         {% endif %}
         <button class="actions__btn actions__btn--right" id="actions-share" data-clipboard-text="{{ my_domain_url }}{% url 'hkm_record' finna_id=record.id %}" data-toggle="tooltip" data-placement="top" tooltip-title="{% trans 'Share' %}">
           <i class="actions__icon">

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -546,6 +546,8 @@ class SearchView(BaseView):
                         collection__owner=request.user,
                         collection__collection_type=Collection.TYPE_FAVORITE
                     ).values_list("record_id", flat=True)
+                    if self.record:
+                        self.record['is_favorite'] = self.record['id'] in favorite_records
                 except Record.DoesNotExist:
                     pass
 
@@ -556,7 +558,7 @@ class SearchView(BaseView):
                     record['index'] = p * self.search_result['limit'] + i
                     i += 1
                     # Check also if this record is one of user's favorites
-                    if favorite_records:
+                    if favorite_records is not None:
                         record['is_favorite'] = record['id'] in favorite_records
                 # If user is loading more pictures add them to session.
                 # Check for page changed, this will prevent session duplicating itself


### PR DESCRIPTION
After these changes record stays as favourite after page refresh. I also fixed other bug: If favourites collection contained single image and it was removed in record detail view, it would show as a favourite when returning to search list.

In previous PR where I refactored record actions, I didn't notice that image URL was set in contex so I removed the duplicate URL fetching.