### PR TITLE
HEL-204 | Hide buy button if album edit is toggled

### DIFF
--- a/hkm/static/hkm/js/hkm-v2.js
+++ b/hkm/static/hkm/js/hkm-v2.js
@@ -681,6 +681,7 @@ palikka
   $title = $('.banner__title');
   $description = $('.banner__description');
   $collectionForm = $('.banner__form');
+  $buyButton = $('.grid__item--buy')
 
   $removeItem.on('click', function() {
     var confirmRemove = confirm($(this).attr('data-confirm'));
@@ -701,6 +702,7 @@ palikka
     $description.toggle();
     $collectionForm.toggle();
     $removeItem.toggle();
+    $buyButton.toggle();
   });
 
   $editBtn.on('click', function() {
@@ -708,6 +710,7 @@ palikka
     $description.toggle();
     $collectionForm.toggle();
     $removeItem.toggle();
+    $buyButton.toggle();
   });
 
 })


### PR DESCRIPTION
Previously if user was one of their albums and edit was toggled, "buy" button was on top of the delete button. Now, when edit is toggled, buy button is hidden from the view.