### PR TITLE
HEL-54 | Stop repeating favorites queries in collection view

### DIFF
--- a/hkm/models/models.py
+++ b/hkm/models/models.py
@@ -232,17 +232,6 @@ class Record(OrderedModel, BaseModel):
         LOG.debug('Got web image absolute url', extra={'data': {'url': url}})
         return url
 
-    def is_favorite(self, user):
-        if user.is_authenticated():
-            try:
-                favorites_collection = Collection.objects.get(
-                    owner=user, collection_type=Collection.TYPE_FAVORITE)
-            except Collection.DoesNotExist:
-                pass
-            else:
-                return favorites_collection.records.filter(record_id=self.record_id).exists()
-        return False
-
 
 @receiver(post_save, sender=User)
 def user_post_save(sender, instance, created, *args, **kwargs):

--- a/hkm/templates/hkm/views/collection.html
+++ b/hkm/templates/hkm/views/collection.html
@@ -72,7 +72,7 @@
               </a>
             <a href="{% url 'hkm_collection' collection_id=collection.id %}?rid={{ record.id }}">
               {% if user.is_authenticated %}
-                <div class="grid__fav {% if record|is_favorite:user %}active{% endif %}" data-record-id="{{ record.record_id }}">
+                <div class="grid__fav {% if record.is_favorite %}active{% endif %}" data-record-id="{{ record.record_id }}">
                   <i class="grid__fav-icon">
                     <svg class="svg-icon">
                       <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-heart-stroke"></use>
@@ -86,7 +86,7 @@
               <span class="grid__meta--title">{{ record.finna_entry.title }}</span>
               <span class="grid__meta--other"></span>
               {% if user.is_authenticated %}
-                <button class="grid__fav {% if record|is_favorite:user %}active{% endif %}" data-record-id="{{ record.record_id }}">
+                <button class="grid__fav {% if record.is_favorite %}active{% endif %}" data-record-id="{{ record.record_id }}">
                     <i class="grid__fav-icon">
                       <svg class="svg-icon">
                         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-heart-stroke"></use>

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -45,11 +45,6 @@ def display_images(collection):
     return image_urls
 
 
-@register.filter
-def is_favorite(record, user):
-    return record.is_favorite(user)
-
-
 @register.filter(is_safe=True)
 def localized_decimal(value, arg=-1):
     formatted_value = floatformat(value, arg)


### PR DESCRIPTION
When the app is displaying a collections' records list, it needs to know
what records are marked as a favorite by the currently logged in user.
Earlier this was done in the template by calling `Record.is_favorite()`
which then made database queries. This resulted in 2*(num of records)
queries for every collection details view. The queries are quite fast
so the user would not experience a lot of delay because of them, but
they were still unnecessary.

I changed this now so that the favorites are fetched only once in the
view's setup phase. The view marks the listed records with `is_favorite`
which is then used by the template.

I also removed the now-obsolete `Record.is_favorite()` to prevent this from
happening again.