### PR TITLE
HEL-216, HEL-196, HEL-58 | Style fixes

### DIFF
--- a/hkm/static/hkm/css/main.css
+++ b/hkm/static/hkm/css/main.css
@@ -7635,16 +7635,16 @@ a.welcome-modal__clarification {
   height: 60px;
   background-color: #fff;
   display: block;
-  font-size: 18px;
-  padding-left: 5px; }
+  font-size: 18px; }
   .navigation__logo {
     display: block;
     width: 200px;
     height: 100%;
-    max-height: 60px; }
+    max-height: 60px;
+    margin-left: 5px; }
   @media (min-width: 650px) {
-    .navigation {
-      padding-left: 30px; } }
+    .navigation__logo {
+      margin-left: 30px; } }
 
 .navigation-header {
   margin-right: auto;
@@ -7828,15 +7828,20 @@ button.navbar-toggle {
 @media (max-width: 944px) {
   .list-item_lang-wrapper {
     order: 5;
-    margin: 0 auto; }
+    margin: 10px auto; }
   .list-item_search {
     order: 1; }
   .list-item_collection {
     order: 2; }
   .list-item_user, .list-item_login {
     order: 3; }
+  .list-item_user {
+    margin-left: -20px; }
   .list-item_cart {
     order: 4; } }
+
+.navbar-collapse {
+  padding: 0; }
 
 @media (min-width: 946px) {
   .navigation .collapse {

--- a/hkm/static/hkm/css/main.css
+++ b/hkm/static/hkm/css/main.css
@@ -7843,6 +7843,12 @@ button.navbar-toggle {
 .navbar-collapse {
   padding: 0; }
 
+.navbar-toggle {
+  right: 0; }
+  @media (min-width: 650px) {
+    .navbar-toggle {
+      right: 30px; } }
+
 @media (min-width: 946px) {
   .navigation .collapse {
     display: block;

--- a/hkm/static/hkm/scss/_navbar.scss
+++ b/hkm/static/hkm/scss/_navbar.scss
@@ -3,18 +3,21 @@
     background-color: $color-white;
     display: block;
     font-size: 18px;
-    padding-left: 5px;
 
     &__logo {
         display: block;
         width: 200px;
         height: 100%;
         max-height: 60px;
+        margin-left: 5px;
     }
 
     @media (min-width: 650px) {
-        padding-left: 30px;
+        &__logo {
+            margin-left: 30px;
+        }
     }
+
 }
 
 .navigation-header {
@@ -275,7 +278,7 @@ button.navbar-toggle {
     @media (max-width: 944px) {
         &_lang-wrapper {
             order: 5;
-            margin: 0 auto;
+            margin: 10px auto;
         }
 
         &_search {
@@ -291,10 +294,18 @@ button.navbar-toggle {
             order: 3;
         }
 
+        &_user {
+            margin-left: -20px;
+        }
+
         &_cart {
             order: 4;
         }
     }
+}
+
+.navbar-collapse {
+    padding: 0;
 }
 
 @media (min-width: 946px) {

--- a/hkm/static/hkm/scss/_navbar.scss
+++ b/hkm/static/hkm/scss/_navbar.scss
@@ -308,6 +308,14 @@ button.navbar-toggle {
     padding: 0;
 }
 
+.navbar-toggle {
+    right: 0;
+
+    @media (min-width: 650px) {
+        right: 30px;
+    }
+}
+
 @media (min-width: 946px) {
     .navigation {
         .collapse {

--- a/hkm/templates/hkm/base_viewer.html
+++ b/hkm/templates/hkm/base_viewer.html
@@ -273,7 +273,7 @@
                   <span class="input-group-addon">
                     <input type="radio" checked="checked" name="collection" data-action="add-create-collection">
                   </span>
-                  <input type="text" class="form-control" id="add-collection-input" value="{% trans 'New collection' %}">
+                  <input type="text" class="form-control" id="add-collection-input" placeholder="{% trans 'New collection' %}">
                 </div>
               </div>
             </div>

--- a/hkm/templates/hkm/snippets/nav_basket_counter.html
+++ b/hkm/templates/hkm/snippets/nav_basket_counter.html
@@ -6,6 +6,7 @@
     <img class="cart_svg" src="/static/hkm/svg/ShoppingCart.svg" alt="shopping">
     <div class="cart_counter">{{ request.basket.product_count }}</div>
     {% else %}
+    <div class="cart_text">{% trans 'Shopping cart' %}</div>
     <img class="cart_svg" src="/static/hkm/svg/ShoppingCart.svg" alt="shopping">
     {% endif %}
   </div>

--- a/hkm/templates/hkm/views/my_collections.html
+++ b/hkm/templates/hkm/views/my_collections.html
@@ -5,7 +5,7 @@
 {% block banner %}
 
   <div class="page-header white">
-    <div class="fullsize-container container">
+    <div class="fullsize-container">
       <div class="banner__title">
         <h1 class="banner__h1">{% trans 'My collections' %}</h1>
       </div>
@@ -16,7 +16,7 @@
 
 {% block content %}
 
-  <div class="fullsize-container container">
+  <div class="fullsize-container">
 
     {% if not collections %}
       <a href="{% url 'hkm_search' %}" class="hkm-btn hkm-btn--default btn btn-default">{% trans 'Add images' %}</a>


### PR DESCRIPTION
In this PR I made little tweaks to layout.
- [HEL-216](https://helsinkisolutionoffice.atlassian.net/browse/HEL-216) In Own albums view, I removed `container` class to align page to the left with correct margings. 
- [HEL-196](https://helsinkisolutionoffice.atlassian.net/browse/HEL-196) When mobile navigation is toggled, correctly show `Shopping cart text`, I also aligned `User` text and icon. I also removed paddings from the wrapper and moved them to logo and menu button instead. Mobile menu width is now correctly 100%.
- [HEL-58](https://helsinkisolutionoffice.atlassian.net/browse/HEL-58) When adding new image to album, user was required to delete the `New album` text before typing anything. I moved this text to placeholder to improve usability.
