### PR TITLE
HEL-232 | Prevent invalid Finna queries

### DIFF
--- a/hkm/finna.py
+++ b/hkm/finna.py
@@ -76,6 +76,10 @@ class FinnaClient(object):
         return result_data
 
     def get_record(self, record_id):
+        if record_id is None:
+            LOG.warn('Record id was None, cannot call Finna')
+            return None
+
         url = FinnaClient.API_ENDPOINT + 'record'
         payload = {
             'id[]': record_id,

--- a/hkm/urls.py
+++ b/hkm/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
         views.CollectionDetailView.as_view(), name='hkm_collection'),
 
     url(r'^search/$', views.SearchView.as_view(), name='hkm_search'),
-    url(r'^search/record/$', views.SearchRecordDetailView.as_view(),
+    url(r'^search/details/$', views.SearchRecordDetailView.as_view(),
         name='hkm_search_record'),
 
     url(r'^record/feedback/$', views.RecordFeedbackView.as_view(), name='hkm_record_feedback'),

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -1323,7 +1323,7 @@ class RecordFeedbackView(View):
             record = request.POST.get("hkm_id", "")
             feedback = form.save(commit=False)
             feedback.record_id = record
-            path = "/info/" if not record else '/search/record/?image_id=' + record
+            path = "/info/" if not record else '/search/details/?image_id=' + record
             feedback.sent_from = "".join([request.get_host(), path])
             feedback.save()
             email.send_feedback_notification(feedback.id)


### PR DESCRIPTION
The previous production version of the app was referring to single images as
`(base url)/search/record/?search=some-search-term&page=123` which meant that
the app would do a Finna query with `some-search-term`, pick the 123rd result
and display it to the user.

Now that we've modified the search logic, these links are invalid. They are
however still used, probably in some Google caches or similar, so we've been
getting a lot of such requests in production since launching the service in
Kuva infra.

Our modified search was still using the `/search/record` URL, but it was
expecting an `image_id` parameter which was not being given by the old-style
links. This caused the app to query Finna without the record id, resulting in
a 400 error from Finna.

I've now changed the app's logic so that the search results are displayed using
`/search/details`. This causes our app to respond with a 404 to the old-style
requests which should (hopefully) cause Google's caches and all the other
places to invalidate their links.

I've also added a check to the Finna logic so that if it somehow gets an empty
record id as parameter, it won't query Finna.