### PR TITLE
HEL-233 | Add support for legacy image urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 # [Unreleased]
 ### Added
 - Analytics usage may now be switched on/off with an environment variable
+- Old-style links to image details are now supported.
 
 ### Fixed
 - Logos disappearing when user entered shopping cart and checkout views.

--- a/hkm/urls.py
+++ b/hkm/urls.py
@@ -28,6 +28,8 @@ urlpatterns = [
     url(r'^search/$', views.SearchView.as_view(), name='hkm_search'),
     url(r'^search/details/$', views.SearchRecordDetailView.as_view(),
         name='hkm_search_record'),
+    url(r'^record/(?P<finna_id>[a-zA-Z0-9:.]+)/$', views.LegacyRecordDetailView.as_view(),
+        name='hkm_legacy_record_details'),
 
     url(r'^record/feedback/$', views.RecordFeedbackView.as_view(), name='hkm_record_feedback'),
 

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -1341,6 +1341,21 @@ class RecordFeedbackView(View):
             )
 
 
+class LegacyRecordDetailView(RedirectView):
+    """This class provides backward compatibility for links to Finna images written
+    as /record/<finna_id>/. It just redirects to the current implementation of the
+    details view using a 301 redirect."""
+
+    permanent = True
+
+    def get_redirect_url(self, *args, **kwargs):
+        base_url = reverse('hkm_search_record')
+        query_string = urlencode({'image_id': kwargs['finna_id']})
+        url = '{}?{}'.format(base_url, query_string)
+
+        return url
+
+
 # ERROR HANDLERS
 
 


### PR DESCRIPTION
There are currently at least some users and/or services which use the older
versions of image urls to point to image details hosted by our service. We
want to support those urls so the users' links won't get broken.

This PR adds backwards support for the older urls so that the incoming
request redirects to the newer version of the url using a permanent redirect
(301). Basically `/record/<finna_id>/` gets translated to
`/search/details/?image_id=<finna_id>`.