### PR TITLE
HEL-240 | Configure extra data in log entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Analytics usage may now be switched on/off with an environment variable
 - Old-style links to image details are now supported.
+- Log configuration is now set up so that it ensures that the extra `data` parameter is present,
+thus allowing for more detailed logging.
 
 ### Fixed
 - Logos disappearing when user entered shopping cart and checkout views.

--- a/hkm/log_filters.py
+++ b/hkm/log_filters.py
@@ -1,0 +1,13 @@
+import logging
+
+
+class ExtraDataFilter(logging.Filter):
+    """This filter ensures that the log entry has a property named `data`
+    so that our log formats may use that property without KeyErrors in
+    case the log entries don't always add that specific key as an extra
+    parameter."""
+    def filter(self, record):
+        if 'data' not in record.__dict__:
+            record.__dict__['data'] = ''
+
+        return True

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -492,6 +492,7 @@ class SearchView(BaseView):
             if kwargs.get('record'):
                 # Check if user came from list view or from direct link
                 finna_id = request.GET.get('image_id')
+                LOG.debug('Displaying image details', extra={'data': {'finna_id': finna_id}})
                 # Check if record is found in session, if not, get it from finna
                 records = session_search_result.get('records', [])
                 record = next((x for x in records if x['id'] == finna_id), None)

--- a/kuvaselaamo/settings.py
+++ b/kuvaselaamo/settings.py
@@ -264,14 +264,20 @@ LOG_LEVEL = env('LOG_LEVEL')
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    'filters': {
+        'extra_data_filter': {
+            '()': 'hkm.log_filters.ExtraDataFilter'
+        },
+    },
     'formatters': {
         'simple': {
-            'format': '%(levelname)s %(asctime)s %(module)s: %(message)s',
+            'format': '%(levelname)s %(asctime)s %(module)s: %(message)s %(data)s',
         },
     },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
+            "filters": ["extra_data_filter"],
             "formatter": "simple"
         }
     },


### PR DESCRIPTION
Earlier our logging configuration only logged the basic message for each log
entry. Many log entries in the app however are adding extra data into each
entry using the `extra` dictionary parameter, but we couldn't add that data
into the log because those entries without the extra data would crash with a
`KeyError`.

I added a new log filter which ensures that the logged `LogRecord` will
always have the property `data` which is now used in the log formatter so
that we can see the extra data in the logs.