### PR TITLE
HEL-233 | Fix record's feedback url

### DIFF
--- a/hkm/urls.py
+++ b/hkm/urls.py
@@ -28,10 +28,9 @@ urlpatterns = [
     url(r'^search/$', views.SearchView.as_view(), name='hkm_search'),
     url(r'^search/details/$', views.SearchRecordDetailView.as_view(),
         name='hkm_search_record'),
+    url(r'^record/feedback/$', views.RecordFeedbackView.as_view(), name='hkm_record_feedback'),
     url(r'^record/(?P<finna_id>[a-zA-Z0-9:.]+)/$', views.LegacyRecordDetailView.as_view(),
         name='hkm_legacy_record_details'),
-
-    url(r'^record/feedback/$', views.RecordFeedbackView.as_view(), name='hkm_record_feedback'),
 
     url(r'^signup/$', restrict_for_museum(views.SignUpView.as_view()), name='hkm_signup'),
     url(r'^language/$', views.LanguageView.as_view(), name='hkm_language'),


### PR DESCRIPTION
The url `record/feedback` was not working, since the last change overrode its
url mapping. I changed the order so that it works and the rest of the similar
urls will go to the legacy mapping `record/<finna_id>`.