### PR TITLE
HEL-225 | Order confirmation was still missing logos

### DIFF
--- a/hkm/views/checkout.py
+++ b/hkm/views/checkout.py
@@ -141,7 +141,7 @@ class OrderPBWNotify(View):
 # be sent to print
 
 
-class OrderConfirmation(TemplateView):
+class OrderConfirmation(BaseCheckoutView):
     template_name = 'hkm/views/order_show_result.html'
     url_name = 'hkm_order_confirmation'
     result = {}


### PR DESCRIPTION
I missed one class when I was fixing logos last time. `OrderConfirmation` now extends `BaseCheckoutView` and should get the language attribute.