### PR TITLE
HEL-238 | Remove duplicate collections from "browse albums" view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ thus allowing for more detailed logging.
 - Logos disappearing when user entered shopping cart and checkout views.
 - Record details should no longer show extra commas after end of the line.
 - Removed extra linefeed symbols from feedback email.
+- "Browse albums" view no longer displays duplicate collections when a collection is both
+public and featured
 
 ## [2.0.1] - 2020-12-09
 ### Fixed

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -194,12 +194,11 @@ class PublicCollectionsView(BaseCollectionListView):
     def get_collection_qs(self, request, *args, **kwargs):
         if request.user.is_authenticated() and request.user.profile.is_museum:
             return request.user.profile.albums.all()
-        return Collection.objects.filter(is_public=True).order_by('created')
+        return Collection.objects.filter(is_public=True, is_featured=False).order_by('created')
 
     def get_context_data(self, **kwargs):
         context = super(PublicCollectionsView, self).get_context_data(**kwargs)
-        context['featured_collections'] = self.collection_qs.filter(
-            is_featured=True)
+        context['featured_collections'] = Collection.objects.filter(is_featured=True).order_by('created')
         return context
 
 


### PR DESCRIPTION
"Browse albums" used to fetch all public collections which it would display
on the view as users' public albums. The featured albums were separated into
their own list by picking collections marked with `is_featured`. These were
then displayed separately on the view.

I changed this so that the users' public collections do not contain those
which are marked with `is_featured` so that the two lists do not contain
duplicate entries.