### PR TITLE
HEL-234 | Restore back to search option

### DIFF
--- a/hkm/templates/hkm/views/search_record.html
+++ b/hkm/templates/hkm/views/search_record.html
@@ -20,7 +20,7 @@
 {% block content %}
 
   {% if search_result %}
-    {% if previous_record or next_record %}
+    {% if not single_image %}
       <div class="back-to">
         <span class="back-to__title">{{ record.title }}</span><br>
         <span>{% trans 'Search' %}: {{ search_term }} ({{ record.index }}/{{search_result.resultCount}})</span><br>

--- a/hkm/templates/hkm/views/search_record.html
+++ b/hkm/templates/hkm/views/search_record.html
@@ -20,7 +20,7 @@
 {% block content %}
 
   {% if search_result %}
-    {% if record.index %}
+    {% if previous_record or next_record %}
       <div class="back-to">
         <span class="back-to__title">{{ record.title }}</span><br>
         <span>{% trans 'Search' %}: {{ search_term }} ({{ record.index }}/{{search_result.resultCount}})</span><br>

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -437,6 +437,7 @@ class SearchView(BaseView):
     previous_record = None
     record = None
     next_record = None
+    single_image = False
 
     search_term = None
     page = 1
@@ -497,6 +498,7 @@ class SearchView(BaseView):
                 if not record:
                     result = FINNA.get_record(finna_id)
                     self.search_result = result
+                    self.single_image = True
                     self.record = result.get('records')[0] if result else None
                 # If user came from list view, get selected image from session
                 else:
@@ -633,6 +635,7 @@ class SearchRecordDetailView(SearchView):
             context['record'] = record
             context['next_record'] = self.next_record
             context['hkm_id'] = record['id']
+            context['single_image'] = self.single_image
             LOG.debug('record id', extra={'data': {'finnaid': record['id']}})
             context['record_web_url'] = FINNA.get_image_url(record['id'])
         if self.request.user.is_authenticated():


### PR DESCRIPTION
Back to search option ended up being hidden when user navigated from search view to image details view.
Search option is shown when application detects that `previous/ next` record is present, if these are absent, user has used direct link and search option is hidden.