### PR TITLE
HEL-245 | Fix record index logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+# [Unreleased]
+### Fixed
+- When "Load more" is pressed record index counting should start at correct place.
+
 # [2.1.0] - 2020-12-17
 ### Added
 - Analytics usage may now be switched on/off with an environment variable

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -539,8 +539,12 @@ class SearchView(BaseView):
 
             if not self.search_result.get('resultCount') == 0 and 'records' in self.search_result and not kwargs.get(
                     'record'):
+                # Loop through records and set index (it is used in "back to search" part) to
+                # display image number / total images, e.g 1/10 000
                 # Check also if this record is one of user's favorites
-                for idx, record in enumerate(self.search_result['records'], 1):
+                session_length = len(session_search_result.get('records', []))
+                start_number = session_length + 1 if search_term_changed or page_changed else 1
+                for idx, record in enumerate(self.search_result['records'], start_number):
                     record['index'] = idx
                     if favorite_records is not None:
                         record['is_favorite'] = record['id'] in favorite_records


### PR DESCRIPTION
Previously I reworked `record.index` logic to use `for loop`'s index. This caused counting to start always at 1 which resulted in showing wrong information in "back to search" section. 

This should now be fixed, if session has records and "Load more" is pressed, it starts at correct position.

[HEL-245](https://helsinkisolutionoffice.atlassian.net/browse/HEL-245)