### PR TITLE
HEL-243 | Remove head query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+# [Unreleased]
+### Changed
+- Remove HEAD query and cache from get_full_res_image_url method.
+
 # [2.1.0] - 2020-12-17
 ### Added
 - Analytics usage may now be switched on/off with an environment variable


### PR DESCRIPTION
This PR removes head query that was made to determine if image has high quality version. Finna functions differently from the Proxy server, and always returns `OK 200` even if image is missing.

[HEL-243](https://helsinkisolutionoffice.atlassian.net/browse/HEL-243)