### PR TITLE
HEL-244 | Header layout is broken on safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+# [Unreleased]
+### Fixed
+- Fix header layout breaking on Safari.
+
 # [2.1.0] - 2020-12-17
 ### Added
 - Analytics usage may now be switched on/off with an environment variable

--- a/hkm/static/hkm/css/main.css
+++ b/hkm/static/hkm/css/main.css
@@ -7782,13 +7782,15 @@ button.navbar-toggle {
     transform: rotate(0); }
 
 .navigation-links {
-  float: right; }
+  float: right;
+  max-height: 70px; }
   .navigation-links ul {
     margin: 0;
     padding: 0;
     display: flex;
     flex-direction: row;
-    align-items: center; }
+    align-items: center;
+    max-height: 70px; }
     .navigation-links ul li {
       list-style: none;
       display: inline-block;
@@ -7804,7 +7806,8 @@ button.navbar-toggle {
       .navigation-links ul li > .dropdown-menu {
         display: none; }
       .navigation-links ul li.open > .dropdown-menu {
-        display: block; }
+        display: block;
+        max-height: 140px; }
     .navigation-links ul.dropdown-menu {
       background-color: #fff;
       left: 50%;
@@ -7827,11 +7830,13 @@ button.navbar-toggle {
       background-color: #fff;
       top: 60px;
       width: 100%;
-      z-index: 150; }
+      z-index: 150;
+      max-height: 400px; }
       .navigation-links ul {
         width: 100%;
         text-align: center;
-        flex-direction: column; }
+        flex-direction: column;
+        max-height: 400px; }
         .navigation-links ul li {
           display: block; }
           .navigation-links ul li a {
@@ -7891,8 +7896,8 @@ button.navbar-toggle {
 
 .cart_icons {
   min-width: 55px;
-  height: 100%;
   display: flex;
+  height: 25px;
   justify-content: space-between; }
 
 .cart_svg {

--- a/hkm/static/hkm/scss/_navbar.scss
+++ b/hkm/static/hkm/scss/_navbar.scss
@@ -37,7 +37,7 @@ button.navbar-toggle {
     span {
         background-color: $color-hkm-purple;
         transition: all 0.15s ease;
-        
+
         &:nth-child(2) {
             transform: rotate(40deg);
             transform-origin: left;
@@ -74,6 +74,7 @@ button.navbar-toggle {
 
 .navigation-links {
     float: right;
+    max-height: 70px;
 
     ul {
         margin: 0;
@@ -81,6 +82,7 @@ button.navbar-toggle {
         display: flex;
         flex-direction: row;
         align-items: center;
+        max-height: 70px;
 
         li {
             list-style: none;
@@ -107,6 +109,7 @@ button.navbar-toggle {
             &.open {
                 > .dropdown-menu {
                     display: block;
+                    max-height: 140px;
                 }
             }
         }
@@ -142,11 +145,13 @@ button.navbar-toggle {
         top: 60px;
         width: 100%;
         z-index: 150;
+        max-height: 400px;
 
         ul {
             width: 100%;
             text-align: center;
             flex-direction: column;
+            max-height: 400px;
 
             li {
                 display: block;
@@ -227,8 +232,8 @@ button.navbar-toggle {
 
     &_icons {
         min-width: 55px;
-        height: 100%;
         display: flex;
+        height: 25px;
         justify-content: space-between;
     }
 


### PR DESCRIPTION
Header layout was broken on safari. After these changes it behaves the same way as Chrome and Firefox.

![image](https://user-images.githubusercontent.com/25960123/102584459-2c640780-410f-11eb-8505-57295db5fb9f.png)

vs 

![image](https://user-images.githubusercontent.com/25960123/102584499-3e45aa80-410f-11eb-8c50-6220396601b2.png)

