### PR TITLE
HEL-224 | Log outcomes of login attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 # [Unreleased]
 ### Added
 - Added lang attribute to language menu.
+- Login attempts (success/failure) are now logged.
 
 ### Changed
 - Add to collection modal no longer shows cropper.

--- a/hkm/apps.py
+++ b/hkm/apps.py
@@ -7,4 +7,5 @@ class DefaultConfig(AppConfig):
     name = 'hkm'
     verbose_name = 'hkm'
 
-
+    def ready(self):
+        import auditlog_signals

--- a/hkm/auditlog_signals.py
+++ b/hkm/auditlog_signals.py
@@ -1,0 +1,32 @@
+import logging
+from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
+from django.dispatch import receiver
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(user_logged_in)
+def user_logged_in_callback(sender, request, user, **kwargs):
+    ip = request.META.get('REMOTE_ADDR')
+
+    logger.info('user logged in: {user} via ip: {ip}'.format(
+        user=user,
+        ip=ip
+    ))
+
+
+@receiver(user_logged_out)
+def user_logged_out_callback(sender, request, user, **kwargs):
+    ip = request.META.get('REMOTE_ADDR')
+
+    logger.debug('user logged out: {user} via ip: {ip}'.format(
+        user=user,
+        ip=ip
+    ))
+
+
+@receiver(user_login_failed)
+def user_login_failed_callback(sender, credentials, **kwargs):
+    logger.warning('user login failed: {credentials}'.format(
+        credentials=credentials,
+    ))

--- a/kuvaselaamo/settings.py
+++ b/kuvaselaamo/settings.py
@@ -282,7 +282,12 @@ LOGGING = {
         }
     },
     "loggers": {
-        "": {
+        'hkm.auditlog_signals': {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False
+        },
+        '': {
             "handlers": ["console"],
             "level": LOG_LEVEL
         },


### PR DESCRIPTION
The app was not creating any log for login attempts which might make it more
vulnerable to misuse.

I added some signal handlers for login events so that they are now logged to
console whose output is in turn sent to a centralized service where the log
entries may be viewed.

The following levels are used:
- failed login: warning
- succeeded login: info
- logout: debug

The configuration is set to log INFO and above.