### PR TITLE
HEL-150 | Browsing collections is challenging with screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added script that deletes old and unused data.
 
+### Fixed
+- Added lang attribute to all collections. It will force screen reader language to finnish.
+
 # [2.3.0] 2021-01-12
 ### Added
 - Added lang attribute to language menu.

--- a/hkm/templates/hkm/views/home_page.html
+++ b/hkm/templates/hkm/views/home_page.html
@@ -41,7 +41,7 @@
           <div class="featured__wrapper">
             {% with collections=showcase|showcase_collections %}
               {% for collection in collections %}
-                <a class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
+                <a lang="fi" aria-label="{{ collection.title }}" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
                   <div class="card">
                     {% with images=collection|display_images %}
                       {% if images|length == 1 %}

--- a/hkm/templates/hkm/views/home_page.html
+++ b/hkm/templates/hkm/views/home_page.html
@@ -41,7 +41,7 @@
           <div class="featured__wrapper">
             {% with collections=showcase|showcase_collections %}
               {% for collection in collections %}
-                <a lang="fi" aria-label="{{ collection.title }}" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
+                <a lang="fi" aria-label="{{ collection.title }} omistaja Helsingin kaupunginmuseo" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
                   <div class="card">
                     {% with images=collection|display_images %}
                       {% if images|length == 1 %}

--- a/hkm/templates/hkm/views/my_collections.html
+++ b/hkm/templates/hkm/views/my_collections.html
@@ -26,7 +26,7 @@
       <div class="grid__group item-slider invisible" data-grid-type="collection">
         {% for collection in collections %}
           <div class="grid__item item" data-w="550" data-h="400">
-            <a href="{% url 'hkm_collection' collection_id=collection.id %}">
+            <a lang="fi" aria-label="{{ collection.title }}" href="{% url 'hkm_collection' collection_id=collection.id %}">
               {% with images=collection|display_images %}
                 {% if images|length == 1 %}
                   <div class="grid__item grid__item--collection" style="background-image:url('{{ images.0 }}')"></div>

--- a/hkm/templates/hkm/views/my_collections.html
+++ b/hkm/templates/hkm/views/my_collections.html
@@ -26,7 +26,7 @@
       <div class="grid__group item-slider invisible" data-grid-type="collection">
         {% for collection in collections %}
           <div class="grid__item item" data-w="550" data-h="400">
-            <a lang="fi" aria-label="{{ collection.title }}" href="{% url 'hkm_collection' collection_id=collection.id %}">
+            <a lang="{% if collection.collection_type == 'favorite' %}{{ language }}{% else %}fi{% endif %}" aria-label="{{ collection.title }}" href="{% url 'hkm_collection' collection_id=collection.id %}">
               {% with images=collection|display_images %}
                 {% if images|length == 1 %}
                   <div class="grid__item grid__item--collection" style="background-image:url('{{ images.0 }}')"></div>

--- a/hkm/templates/hkm/views/public_collections.html
+++ b/hkm/templates/hkm/views/public_collections.html
@@ -10,7 +10,7 @@
       <div class=public-collections__content>
         <div class="public-collections__wrapper">
           {% for collection in featured_collections %}
-          <a class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
+          <a lang="fi" aria-label="{{ collection.title }}" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
             <div class="card">
               {% with images=collection|display_images %}
               {% if images|length == 1 %}
@@ -45,7 +45,7 @@
       <div class="public-collections__wrapper">
         {% for collection in collections %}
           {% if collection.records.all %}
-            <a class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
+            <a lang="fi" aria-label="{{ collection.title }}" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
               <div class="card">
                 {% with images=collection|display_images %}
                 {% if images|length == 1 %}

--- a/hkm/templates/hkm/views/public_collections.html
+++ b/hkm/templates/hkm/views/public_collections.html
@@ -10,7 +10,7 @@
       <div class=public-collections__content>
         <div class="public-collections__wrapper">
           {% for collection in featured_collections %}
-          <a lang="fi" aria-label="{{ collection.title }}" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
+          <a lang="fi" aria-label="{{ collection.title }} omistaja Helsingin kaupunginmuseo" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
             <div class="card">
               {% with images=collection|display_images %}
               {% if images|length == 1 %}
@@ -45,7 +45,7 @@
       <div class="public-collections__wrapper">
         {% for collection in collections %}
           {% if collection.records.all %}
-            <a lang="fi" aria-label="{{ collection.title }}" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
+            <a lang="fi" aria-label="{{ collection.title }} omistaja {{ collection.owner }}" class="card-link" href="{% url 'hkm_collection' collection_id=collection.id %}">
               <div class="card">
                 {% with images=collection|display_images %}
                 {% if images|length == 1 %}


### PR DESCRIPTION
Due the missing translations on collection titles, `lang="fi"` attribute was added to all collections. It will force screen reader to read titles in finnish.

Manual testing instructions:
Using screen reader
1. Navigate to home page -> showcase collection titles should be read in finnish.
2. Navigate to "Explore albums" page -> title should be read in finnish.
3. Navigate to "Own albums" -> again titles should be read in finnish. When user creates favourite album the first time, its language is determined by users current language at the time. Favourites album should be read with the users current language.