### PR TITLE
HEL-247 | Restrict which users are deleted

### DIFF
--- a/hkm/management/commands/clean_unused_data.py
+++ b/hkm/management/commands/clean_unused_data.py
@@ -23,7 +23,9 @@ class Command(BaseCommand):
         counted_date = timezone.now() - timedelta(days=days)
 
         # Find and delete unused users. Do not delete superusers or staff users.
-        users = User.objects.filter(last_login__lte=counted_date, is_superuser=False, is_staff=False).delete()
+        users = User.objects.filter(last_login__lte=counted_date, is_superuser=False, is_staff=False,
+                                    profile__is_museum=False, profile__is_admin=False).delete()
+        print(users)
 
         # Find and delete old TmpImages, Feedbacks and Orders
         temps = TmpImage.delete_old_data(counted_date)

--- a/hkm/management/commands/clean_unused_data.py
+++ b/hkm/management/commands/clean_unused_data.py
@@ -25,7 +25,6 @@ class Command(BaseCommand):
         # Find and delete unused users. Do not delete superusers or staff users.
         users = User.objects.filter(last_login__lte=counted_date, is_superuser=False, is_staff=False,
                                     profile__is_museum=False, profile__is_admin=False).delete()
-        print(users)
 
         # Find and delete old TmpImages, Feedbacks and Orders
         temps = TmpImage.delete_old_data(counted_date)

--- a/hkm/management/commands/clean_unused_data.py
+++ b/hkm/management/commands/clean_unused_data.py
@@ -22,8 +22,8 @@ class Command(BaseCommand):
         self.stdout.write("Old data cleaning started! Removing data older than " + str(days) + " days.")
         counted_date = timezone.now() - timedelta(days=days)
 
-        # Find and delete unused users
-        users = User.objects.filter(last_login__lte=counted_date).delete()
+        # Find and delete unused users. Do not delete superusers or staff users.
+        users = User.objects.filter(last_login__lte=counted_date, is_superuser=False, is_staff=False).delete()
 
         # Find and delete old TmpImages, Feedbacks and Orders
         temps = TmpImage.delete_old_data(counted_date)

--- a/hkm/models/models.py
+++ b/hkm/models/models.py
@@ -465,7 +465,7 @@ class TmpImage(BaseModel):
 
     @classmethod
     def delete_old_data(self, date):
-        return self.objects.filter(modified__lte=date).delete()
+        return self.objects.filter(modified__lte=date, creator__isnull=True).delete()
 
     def __unicode__(self):
         return self.record_title


### PR DESCRIPTION
Made a change to `clean_unused_data` script. Super users and staff are no longer deleted. I could't figure out a better way to do this. Before this change goes to into use, we need to make sure that all correct accounts are market as staff.