### PR TITLE
HEL-258 | Disable logging for /healthz and /readiness

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -8,3 +8,6 @@ gid = nogroup
 master = 1
 processes = 2
 threads = 2
+; don't log readiness and healthz endpoints
+route = ^/readiness$ donotlog:
+route = ^/healthz$ donotlog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Moved CGS / Azure dependencies to environment specific requirements.in files.
+- Disabled logging for /healthz and /readiness endpoints.
 
 
 # [2.3.0] 2021-01-12


### PR DESCRIPTION
Healthz and readiness endpoints are requested continuously by our infra. This
creates an awful lot of unnecessary log.

I disabled the logging for the endpoints using uwsgi configs.