### PR TITLE
HEL-264 | Fix shopping cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added lang attribute to all collections. It will force screen reader language to finnish.
 - Fixed missing title tags to all unique pages.
 - If image is not found with image_id, correct error is shown.
+- Shopping cart buttons (increase, decrease, delete)
 
 ### Changed
 - Moved CGS / Azure dependencies to environment specific requirements.in files.

--- a/hkm/views/views.py
+++ b/hkm/views/views.py
@@ -1234,21 +1234,21 @@ class BasketView(BaseView):
     def render_basket_total_row(self):
         html = loader.render_to_string(
             "hkm/snippets/_basket_total_row.html",
-            context=RequestContext(self.request, self.get_context_data())
+            context=RequestContext(self.request, self.get_context_data()).flatten()
         )
         return html
 
     def render_nav_product_counter(self):
         html = loader.render_to_string(
             "hkm/snippets/nav_basket_counter.html",
-            context=RequestContext(self.request, self.get_context_data())
+            context=RequestContext(self.request, self.get_context_data()).flatten()
         )
         return html
 
     def render_basket_html(self):
         html = loader.render_to_string(
             "hkm/views/_basket_content.html",
-            context=RequestContext(self.request, self.get_context_data(include_base=True))
+            context=RequestContext(self.request, self.get_context_data(include_base=True)).flatten()
         )
         return html
 


### PR DESCRIPTION
When I upgraded django version from 1.10 to 1.11, `RequestContext` method was changed and was not returning an object. I used provided `.flatten()` to fix this issue.