### PR TITLE
HEL-42 | Show cropped images in shopping basket view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed missing title tags to all unique pages.
 - If image is not found with image_id, correct error is shown.
 - Shopping cart buttons (increase, decrease, delete)
+- The shopping basket view now displays images based on the crop selection made by the user.
 
 ### Changed
 - Moved CGS / Azure dependencies to environment specific requirements.in files.

--- a/hkm/templates/hkm/views/_basket_content.html
+++ b/hkm/templates/hkm/views/_basket_content.html
@@ -5,7 +5,7 @@
 
     <div class="basket-thumbnail">
         <figure class="basket-thumbnail_figure">
-            <img src="{{ line.order.image_url }}" alt="">
+            <img src="{{ line.order.crop_image_url }}" alt="">
             <figcaption>{{ line.product.get_name_display }}</figcaption>
         </figure>
     </div>


### PR DESCRIPTION
Earlier the shopping basket view was displaying the actual full resolution
images from Finna for each line in the order. This meant that the browser
fetched several megabytes from Finna only to display the images as small
thumbnails. In addition, the thumbnails contained the whole image and not
the actual cropped part which the user had selected, probably causing a lot
of confusion about what the user was ordering.

The cropped image's url was already made available when the basket was
displayed, so I just changed the view to use the cropped image's url
instead of the Finna url.