### PR TITLE
HEL-125 | Add environment variable for pwd reset link validity period

### DIFF
--- a/docker-compose.env.example.yaml
+++ b/docker-compose.env.example.yaml
@@ -45,3 +45,6 @@ MAIL_MAILGUN_API=
 
 # Level of logging. Defaults to ERROR in settings.py
 LOG_LEVEL=DEBUG
+
+# How many days will the password reset link be valid. Defaults to 1 in settings.
+PASSWORD_RESET_TIMEOUT_DAYS=1

--- a/kuvaselaamo/settings.py
+++ b/kuvaselaamo/settings.py
@@ -31,6 +31,7 @@ env = environ.Env(
     AZURE_ACCOUNT_KEY=(str, ""),
     AZURE_CONTAINER=(str, ""),
     ENABLE_ANALYTICS=(bool, False),
+    PASSWORD_RESET_TIMEOUT_DAYS=(int, 1),
 )
 
 DEBUG = env.bool('DEBUG')
@@ -314,3 +315,5 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "kuvaselaamo.validators.AlphabeticPasswordValidator",
     },
 ]
+
+PASSWORD_RESET_TIMEOUT_DAYS = env('PASSWORD_RESET_TIMEOUT_DAYS')


### PR DESCRIPTION
Django defaults to 3 days when determining the validity period of a password
reset link. This is too much for us, so I added an environment variable for
controlling this value. The value defaults to 1 but it can now be changed if
necessary.