### PR TITLE
HEL-276, HEL-277 | Add browser test that cover a few important user paths

### DIFF
--- a/browser-tests/.env.example
+++ b/browser-tests/.env.example
@@ -1,1 +1,1 @@
-BROWSER_TESTING_BASE_URL=http://localhost:8080/
+BROWSER_TESTING_BASE_URL=http://localhost:8080

--- a/browser-tests/albumFeature.ts
+++ b/browser-tests/albumFeature.ts
@@ -1,0 +1,15 @@
+import * as RouteUtils from "./utils/route";
+import navigation from "./pages/Navigation";
+import imageDetailsPage from "./pages/ImageDetailsPage";
+import albumListPage from "./pages/AlbumListPage";
+import albumPage from "./pages/AlbumPage";
+
+fixture`Album feature`.page(RouteUtils.getRoute("/"));
+
+test("As a user I want to be able to find images through albums", async () => {
+  await navigation.goToAlbumList();
+  await albumListPage.selectFirstCollection();
+  await albumPage.selectFirstImage();
+
+  await imageDetailsPage.hasMainImage();
+});

--- a/browser-tests/imageFeature.ts
+++ b/browser-tests/imageFeature.ts
@@ -1,0 +1,13 @@
+import * as RouteUtils from "./utils/route";
+import imageDetailsPage from "./pages/ImageDetailsPage";
+
+fixture`Image feature`.page(
+  RouteUtils.getImageRoute("hkm.HKMS000005:km0000oh6r")
+);
+
+test("As a user I want to be able to see details of images", async (t) => {
+  await imageDetailsPage.hasMainImage();
+  await t.expect(imageDetailsPage.creator.exists).ok();
+  await t.expect(imageDetailsPage.time.exists).ok();
+  await t.expect(imageDetailsPage.feedbackForm.exists).ok();
+});

--- a/browser-tests/mainSearchFeature.ts
+++ b/browser-tests/mainSearchFeature.ts
@@ -1,0 +1,13 @@
+import * as RouteUtils from "./utils/route";
+import landingPage from "./pages/LandingPage";
+import searchPage from "./pages/SearchPage";
+import imageDetailsPage from "./pages/ImageDetailsPage";
+
+fixture`Main search fucntionality`.page(RouteUtils.getRoute("/"));
+
+test("As a user I want to be able to use the main search functionality to find images", async (t) => {
+  await landingPage.search("Sederholmin talo");
+  await searchPage.selectResult("Sederholmin talo");
+
+  await t.expect(imageDetailsPage.title.innerText).eql("Sederholmin talo");
+});

--- a/browser-tests/pages/AlbumListPage.ts
+++ b/browser-tests/pages/AlbumListPage.ts
@@ -1,0 +1,11 @@
+import { Selector, t } from "testcafe";
+
+class AlbumListPage {
+  firstAlbum = Selector(".public-collections__wrapper").child(0);
+
+  async selectFirstCollection() {
+    return t.click(this.firstAlbum);
+  }
+}
+
+export default new AlbumListPage();

--- a/browser-tests/pages/AlbumPage.ts
+++ b/browser-tests/pages/AlbumPage.ts
@@ -1,0 +1,11 @@
+import { Selector, t } from "testcafe";
+
+class AlbumPage {
+  firstImage = Selector(".grid__group.item-slider").child(0);
+
+  async selectFirstImage() {
+    return t.click(this.firstImage);
+  }
+}
+
+export default new AlbumPage();

--- a/browser-tests/pages/ImageDetailsPage.ts
+++ b/browser-tests/pages/ImageDetailsPage.ts
@@ -1,0 +1,19 @@
+import { Selector, t, ClientFunction } from "testcafe";
+
+class ImageDetailsPage {
+  mainImage = Selector(".image-viewer__image");
+  title = Selector("h1").nth(8);
+  creator = this.recordMeta("Tekijä");
+  time = this.recordMeta("Ajankohta");
+  feedbackForm = Selector("form#feedback-form");
+
+  async hasMainImage() {
+    return t.expect(this.mainImage.exists).ok();
+  }
+
+  recordMeta(title: string) {
+    return Selector(".record-meta__paragraph").withText(`${title}:`);
+  }
+}
+
+export default new ImageDetailsPage();

--- a/browser-tests/pages/LandingPage.ts
+++ b/browser-tests/pages/LandingPage.ts
@@ -1,9 +1,14 @@
-import { Selector } from "testcafe";
+import { Selector, t } from "testcafe";
 
 class LandingPage {
   title = Selector("h1").withText(
     "Tervetuloa Helsinki-aiheisten valokuvien aarreaittaan!"
   );
+  searchInput = Selector("input#search");
+
+  async search(searchTerm: string) {
+    await t.typeText(this.searchInput, searchTerm).pressKey("enter");
+  }
 }
 
 export default new LandingPage();

--- a/browser-tests/pages/Navigation.ts
+++ b/browser-tests/pages/Navigation.ts
@@ -1,0 +1,11 @@
+import { Selector, t } from "testcafe";
+
+class Navigation {
+  albumLink = Selector("a").withText("Selaa albumeita");
+
+  async goToAlbumList() {
+    return t.click(this.albumLink);
+  }
+}
+
+export default new Navigation();

--- a/browser-tests/pages/SearchPage.ts
+++ b/browser-tests/pages/SearchPage.ts
@@ -1,0 +1,13 @@
+import { Selector, t } from "testcafe";
+
+class SearchPage {
+  getResult(resultTitle: string) {
+    return Selector(`img[alt="${resultTitle}"]`);
+  }
+
+  async selectResult(resultTitle: string) {
+    await t.click(this.getResult(resultTitle));
+  }
+}
+
+export default new SearchPage();

--- a/browser-tests/utils/route.ts
+++ b/browser-tests/utils/route.ts
@@ -3,3 +3,7 @@ import settings from "./settings";
 export function getRoute(path: string) {
   return `${settings.baseUrl}${path}`;
 }
+
+export function getImageRoute(imageId: string) {
+  return getRoute(`/search/details/?image_id=${imageId}`);
+}


### PR DESCRIPTION
Adds browser tests that check that the search on the landing page can be used to find images, albums can be used to find images, and that the image page contains the content we expect.