### PR TITLE
HOTFIX | Fix from email variable to orders.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ review:
         K8S_SECRET_ALLOWED_HOSTS: "*"
         K8S_SECRET_DEBUG: 1
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
-        K8S_SECRET_HKM_FEEDBACK_FROM_EMAIL: "no-reply@hel.ninja"
+        K8S_SECRET_HKM_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
         K8S_SECRET_HKM_FEEDBACK_NOTIFICATION_EMAILS: "dummy-address@hel.ninja"
         K8S_SECRET_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
         K8S_SECRET_MAIL_MAILGUN_KEY: "$GL_MAILGUN_API_KEY"
@@ -41,7 +41,7 @@ staging:
         K8S_SECRET_SKIP_DATABASE_CHECK: 1
         K8S_SECRET_SECRET_KEY: "$GL_QA_DJANGO_SECRET_KEY"
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
-        K8S_SECRET_HKM_FEEDBACK_FROM_EMAIL: "no-reply@hel.ninja"
+        K8S_SECRET_HKM_DEFAULT_FROM_EMAIL: "no-reply@hel.ninja"
         K8S_SECRET_HKM_FEEDBACK_NOTIFICATION_EMAILS: "dummy-address@hel.ninja"
         K8S_SECRET_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
         K8S_SECRET_MAIL_MAILGUN_KEY: "$GL_MAILGUN_API_KEY"
@@ -65,7 +65,7 @@ production:
         K8S_SECRET_SKIP_DATABASE_CHECK: 1
         K8S_SECRET_SECRET_KEY: "$GL_STABLE_DJANGO_SECRET_KEY"
         K8S_SECRET_VERSION: "$CI_COMMIT_SHORT_SHA"
-        K8S_SECRET_HKM_FEEDBACK_FROM_EMAIL: "no-reply@hel.fi"
+        K8S_SECRET_HKM_DEFAULT_FROM_EMAIL: "no-reply@hel.fi"
         K8S_SECRET_HKM_FEEDBACK_NOTIFICATION_EMAILS: "dummy-address@hel.ninja"
         K8S_SECRET_EMAIL_BACKEND: "anymail.backends.mailgun.EmailBackend"
         K8S_SECRET_MAIL_MAILGUN_KEY: "$GL_MAILGUN_API_KEY"

--- a/docker-compose.env.example.yaml
+++ b/docker-compose.env.example.yaml
@@ -29,7 +29,7 @@ HKM_PRINTMOTOR_API_KEY=
 HKM_PRINTMOTOR_API_ENDPOINT=
 
 # The "from" address when the app sends emails
-HKM_FEEDBACK_FROM_EMAIL=no-reply@hel.ninja
+HKM_DEFAULT_FROM_EMAIL=no-reply@hel.ninja
 
 # Comma-separated list of email addresses where the app will send feedback
 HKM_FEEDBACK_NOTIFICATION_EMAILS=dummy-address@hel.ninja

--- a/hkm/models/models.py
+++ b/hkm/models/models.py
@@ -725,7 +725,7 @@ class ProductOrderCollection(models.Model):
             subject = 'Helsinkikuvia.fi - tilaus toimitettu painoon'
             message = 'Hei! Tilauksesi on onnistuneesti toimitettu painotalo Printmotorille. Valmis tilaus lähetetään Matkahuollon lähipakettina viimeistään kolmantena arkipäivänä tästä päivästä lukien. Tilaukseen liittyvät yhteydenotot sähköpostitse: support@printmotor.io (mainitse viestissä, että tilaus on tehty Helsinkikuvia.fi-palvelussa).\n\n Helsinkikuvia.fi – helsinkiläisten kuva-aarre verkossa'
 
-        send_mail(subject, message, settings.HKM_FEEDBACK_FROM_EMAIL, [self.customer_email])
+        send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [self.customer_email])
         return True
 
     @property


### PR DESCRIPTION
There was still one remaining `send_main` function with old `HKM_FEEDBACK_FROM_EMAIL`. 
I changed this to `docker-compose.env.example.yaml ` + `.gitlab-ci.yaml` as well.