### PR TITLE
HEL-263 | Clear removal notification timestamp after login

### DIFF
--- a/hkm/models/models.py
+++ b/hkm/models/models.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.signals import user_logged_in
 
 from django.core.cache import caches
 from django.core.exceptions import ValidationError
@@ -33,6 +34,17 @@ from hkm.printmotor_client import client as PRINTMOTOR
 
 LOG = logging.getLogger(__name__)
 DEFAULT_CACHE = caches['default']
+
+
+def _update_removal_notification_sent(sender, user, **kwargs):
+    """
+    A signal receiver which clears the value of removal_notification_sent of the user logging in.
+    """
+    user.profile.removal_notification_sent = None
+    user.profile.save(update_fields=['removal_notification_sent'])
+
+
+user_logged_in.connect(_update_removal_notification_sent)
 
 
 class BaseModel(models.Model):

--- a/hkm/tests/test_signals.py
+++ b/hkm/tests/test_signals.py
@@ -1,0 +1,22 @@
+import pytest
+from django.contrib.auth import signals
+from factories import UserFactory
+from django.test.client import RequestFactory
+from hkm.models.models import UserProfile
+from datetime import datetime, timedelta
+
+
+@pytest.mark.django_db
+def test_that_login_clears_removal_notification_timestamp():
+    user = UserFactory()
+
+    up = user.profile
+    up.removal_notification_sent = datetime.today() - timedelta(days=1)
+    up.save()
+    
+    assert UserProfile.objects.first().removal_notification_sent
+
+    request = RequestFactory().get("/login")
+    signals.user_logged_in.send(sender=user.__class__, request=request, user=user)
+
+    assert not UserProfile.objects.first().removal_notification_sent


### PR DESCRIPTION
When we've sent a notification to a user telling that their account will be
deleted after one month, the user can "cancel" the scheduled deletion by
logging in to the service.

I added a signal handler which sets a user's `removal_notification_sent`
field to null after login. This will affect the scheduled removal so that the
user won't be considered for deletion until 11 months later, if they don't
login before that. At that point, they will get a new notification and their
`removal_notification_sent` is set again.