### PR TITLE
HEL-263 | Add new management command for sending removal notifications

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -119,4 +119,4 @@ jobs:
           target_namespace: ${{ secrets.K8S_NAMESPACE_STAGING }}
           schedule: "0 0 * * *"
           command: "{/bin/sh}"
-          args: "{-c,cd /app && python manage.py clean_unused_data && python manage.py clearsessions}"
+          args: "{-c,cd /app && python manage.py send_removal_notifications && python manage.py clean_unused_data && python manage.py clearsessions}"

--- a/hkm/management/commands/send_removal_notifications.py
+++ b/hkm/management/commands/send_removal_notifications.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from datetime import timedelta
+from django.utils import timezone
+from clean_unused_data import DEFAULT_DAYS_UNTIL_NOTIFICATION
+from django.core.mail import send_mail
+from django.conf import settings
+
+NOTIFICATION_SUBJECT = u"Helsinkikuvia.fi: Käyttäjätunnuksesi poistetaan pian"
+NOTIFICATION_MESSAGE = u"""Hei! Et ole kirjautunut Helsinkikuvia.fi -palveluun pitkään aikaan. Käyttäjätunnuksesi ja siihen liittyvät tiedot poistetaan palvelusta 30 päivän kuluttua.
+
+Jos haluat jatkaa palvelun käyttöä ja säilyttää tietosi, käy kirjautumassa osoitteessa https://helsinkikuvia.fi.
+
+Helsinkikuvia.fi – helsinkiläisten kuva-aarre verkossa"""
+
+
+class Command(BaseCommand):
+    help = "Send an email notification to those users whose account will be removed shortly because of inactivity."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-dn", "--days_until_notification", type=int,
+            help="Specifies the time in days after which a notification warning about removal will be sent to users.",
+            default=DEFAULT_DAYS_UNTIL_NOTIFICATION
+        )
+
+    def handle(self, *args, **kwargs):
+        days_until_notification = kwargs['days_until_notification']
+
+        if days_until_notification < 0:
+            self.stdout.write(self.style.ERROR(
+                "Invalid parameters given. Ensure that days_until_notification is a positive integer."))
+            return
+
+        self.stdout.write(
+            "Starting to send notifications to users whose accounts are about to be removed. Sending "
+            "notifications to users whose last login date is older than %d days." % days_until_notification)
+
+        counted_date = timezone.now() - timedelta(days=days_until_notification)
+        users = User.objects.filter(last_login__lte=counted_date, is_superuser=False, is_staff=False,
+                                    profile__is_museum=False, profile__is_admin=False,
+                                    profile__removal_notification_sent__isnull=True)
+
+        for user in users:
+            send_mail(NOTIFICATION_SUBJECT, NOTIFICATION_MESSAGE, settings.DEFAULT_FROM_EMAIL, [user.email],
+                      fail_silently=False)
+            user.profile.removal_notification_sent = timezone.now()
+            user.profile.save()
+
+        self.stdout.write(
+            self.style.SUCCESS('Removal notification sending finished, %d notifications sent!' % len(users)))

--- a/hkm/tests/factories.py
+++ b/hkm/tests/factories.py
@@ -29,6 +29,7 @@ class UserProfileFactory(factory.django.DjangoModelFactory):
 @factory.django.mute_signals(post_save)
 class UserFactory(factory.django.DjangoModelFactory):
     username = factory.Faker('email')
+    email = factory.LazyAttribute(lambda user: user.username)
     profile = factory.RelatedFactory(UserProfileFactory, factory_related_name='user')
 
     class Meta:

--- a/hkm/tests/settings.py
+++ b/hkm/tests/settings.py
@@ -7,3 +7,5 @@ DATABASES = {
         'ENGINE': 'django.db.backends.sqlite3'
     }
 }
+
+DEFAULT_FROM_EMAIL = "kissa@kissa.com"

--- a/hkm/tests/test_send_removal_notifications.py
+++ b/hkm/tests/test_send_removal_notifications.py
@@ -1,0 +1,139 @@
+import pytest
+from factories import UserFactory
+from hkm.models.models import User
+from django.core.management import call_command
+from freezegun import freeze_time
+from datetime import timedelta
+from django.utils import timezone
+from hkm.management.commands.clean_unused_data import DEFAULT_DAYS_UNTIL_NOTIFICATION
+from mock import patch, DEFAULT
+
+CUSTOM_DAYS_UNTIL_NOTIFICATION = 5
+
+
+@pytest.fixture
+def day_older_than_notification_date():
+    return timezone.now() - timedelta(days=DEFAULT_DAYS_UNTIL_NOTIFICATION + 1)
+
+
+@pytest.fixture
+def day_newer_than_notification_date():
+    return timezone.now() - timedelta(days=DEFAULT_DAYS_UNTIL_NOTIFICATION - 1)
+
+
+@pytest.fixture
+def day_older_than_custom_notification_date():
+    return timezone.now() - timedelta(days=CUSTOM_DAYS_UNTIL_NOTIFICATION + 1)
+
+
+@pytest.fixture
+def day_newer_than_custom_notification_date():
+    return timezone.now() - timedelta(days=CUSTOM_DAYS_UNTIL_NOTIFICATION - 1)
+
+
+def _assert_email_sent(mailoutbox, emails):
+    assert len(mailoutbox) == len(emails)
+
+    for idx, email in enumerate(emails):
+        assert mailoutbox[idx].subject
+        assert mailoutbox[idx].body
+        assert mailoutbox[idx].from_email == 'kissa@kissa.com'
+        assert mailoutbox[idx].to == [email]
+
+
+@pytest.mark.django_db
+def test_that_old_user_gets_notified_using_default_date(day_older_than_notification_date,
+                                                        day_newer_than_notification_date, mailoutbox):
+    now = timezone.now()
+    with freeze_time(now):
+        u1 = UserFactory(last_login=day_older_than_notification_date, profile__removal_notification_sent=None)
+        u2 = UserFactory(last_login=day_newer_than_notification_date, profile__removal_notification_sent=None)
+        u3 = UserFactory(last_login=day_older_than_notification_date,
+                         profile__removal_notification_sent=day_older_than_notification_date)
+
+        call_command('send_removal_notifications')
+
+        assert User.objects.get(pk=u1.id).profile.removal_notification_sent == now
+        assert User.objects.get(pk=u2.id).profile.removal_notification_sent is None
+        assert User.objects.get(pk=u3.id).profile.removal_notification_sent == day_older_than_notification_date
+
+        _assert_email_sent(mailoutbox, [u1.email])
+
+
+@pytest.mark.django_db
+def test_that_old_user_gets_notified_using_custom_date(day_older_than_custom_notification_date,
+                                                       day_newer_than_custom_notification_date,
+                                                       mailoutbox):
+    now = timezone.now()
+    with freeze_time(now):
+        u1 = UserFactory(last_login=day_older_than_custom_notification_date, profile__removal_notification_sent=None)
+        u2 = UserFactory(last_login=day_newer_than_custom_notification_date, profile__removal_notification_sent=None)
+        u3 = UserFactory(last_login=day_older_than_custom_notification_date,
+                         profile__removal_notification_sent=day_older_than_custom_notification_date)
+
+        call_command('send_removal_notifications', days_until_notification=CUSTOM_DAYS_UNTIL_NOTIFICATION)
+
+        assert User.objects.get(pk=u1.id).profile.removal_notification_sent == now
+        assert User.objects.get(pk=u2.id).profile.removal_notification_sent is None
+        assert User.objects.get(pk=u3.id).profile.removal_notification_sent == day_older_than_custom_notification_date
+
+        _assert_email_sent(mailoutbox, [u1.email])
+
+
+def test_negative_days_until_notification(capsys):
+    call_command('send_removal_notifications', days_until_notification=-1)
+
+    assert "Invalid parameters given." in capsys.readouterr()[0]
+
+
+@pytest.mark.django_db
+def test_that_multiple_users_get_notified(day_older_than_notification_date, mailoutbox):
+    now = timezone.now()
+    with freeze_time(now):
+        u1 = UserFactory(last_login=day_older_than_notification_date, profile__removal_notification_sent=None)
+        u2 = UserFactory(last_login=day_older_than_notification_date, profile__removal_notification_sent=None)
+        u3 = UserFactory(last_login=day_older_than_notification_date, profile__removal_notification_sent=None)
+
+        call_command('send_removal_notifications')
+
+        assert User.objects.get(pk=u1.id).profile.removal_notification_sent == now
+        assert User.objects.get(pk=u2.id).profile.removal_notification_sent == now
+        assert User.objects.get(pk=u3.id).profile.removal_notification_sent == now
+
+        _assert_email_sent(mailoutbox, [u1.email, u2.email, u3.email])
+
+
+@pytest.mark.django_db
+def test_no_notifications(day_newer_than_notification_date, mailoutbox):
+    now = timezone.now()
+    with freeze_time(now):
+        u1 = UserFactory(last_login=day_newer_than_notification_date, profile__removal_notification_sent=None)
+
+        call_command('send_removal_notifications')
+
+        assert User.objects.get(pk=u1.id).profile.removal_notification_sent is None
+
+        _assert_email_sent(mailoutbox, [])
+
+
+# This test works but only if run as a single test. There's some funny business going on with @patch,
+# so this is skipped. Maybe in the future when we get a more current Python version, @patch will start
+# working as expected.
+@pytest.mark.skip
+@pytest.mark.django_db
+@patch('django.core.mail.send_mail', side_effect=[DEFAULT, Exception('ka-boom')])
+def test_error_during_email_sending(send_mail, day_older_than_notification_date):
+    now = timezone.now()
+    with freeze_time(now):
+        u1 = UserFactory(last_login=day_older_than_notification_date, profile__removal_notification_sent=None)
+        u2 = UserFactory(last_login=day_older_than_notification_date, profile__removal_notification_sent=None)
+        u3 = UserFactory(last_login=day_older_than_notification_date, profile__removal_notification_sent=None)
+
+        assert User.objects.count() == 3
+
+        with pytest.raises(Exception):
+            call_command('send_removal_notifications')
+
+        assert User.objects.get(pk=u1.id).profile.removal_notification_sent == now
+        assert User.objects.get(pk=u2.id).profile.removal_notification_sent is None
+        assert User.objects.get(pk=u3.id).profile.removal_notification_sent is None


### PR DESCRIPTION
### Summary

Added the new management command `send_removal_notifications` which will
send an email notification to users who have not logged in in a while (=
335 days by default or a custom value if given as a parameter) and who
have not yet received a notification. Also added tests for the command.

I changed the staging environment's config so that the new command will run
before `clean_unused_data`.

### Testing

See the detailed instructions in the ticket: https://helsinkisolutionoffice.atlassian.net/browse/HEL-263

This has now been tested locally according to the ticket + the tests are passing.