### PR TITLE
HEL-263 | Add max duration to staging's cronjob

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -125,3 +125,4 @@ jobs:
           schedule: "0 0 * * *"
           command: "{/bin/sh}"
           args: "{-c,cd /app && python manage.py send_removal_notifications && python manage.py clean_unused_data && python manage.py clearsessions}"
+          max_duration: 900 # 15 minutes


### PR DESCRIPTION
The initial amount of email notifications in production is estimated to be
~1500. Sending that many emails takes over 5 minutes at least in staging
which means that the default value for max duration (5 minutes) is too low.

We want to keep the job running to avoid errors and duplicate emails which
is what is happening in staging, so I bumped this up to 15 minutes.