### PR TITLE
HEL-288 | Skip invalid emails when sending removal notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+# [Unreleased]
+
+### Fixed
+- When sending removal notifications via email, a 400 error from Mailgun is now interpreted so that the email 
+  address is invalid and the user is marked as having been sent the message. This allows the scheduled run to continue 
+  processing.
+
 # [2.5.0] 2021-05-05
 
 ### Added


### PR DESCRIPTION
### Summary

We currently have some invalid email addresses in our user database and
we are not verifying the new users' emails, so we're bound to get more typos
in emails in the future. These invalid addresses caused the scheduled
notification run to crash when it encountered such an address, therefore
stopping the whole notification process.

I added a check which makes sure that when Mailgun responds with a 400 Bad
request, the run will just mark that user as having been sent the message
and continues with the run. If we have a wrong address for a user, then they
are anyway unable to request for a password reset and so their user account
can't be accessed.

I also added a test for this + changed the commands status printouts a bit.

### Testing

This has been tested by running the unit tests + locally by reproducing the issue as described in https://helsinkisolutionoffice.atlassian.net/browse/HEL-288