### PR TITLE
Release/2.5.1

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -83,3 +83,17 @@ jobs:
           K8S_SECRET_DATABASE_PASSWORD: ${{ secrets.K8S_SECRET_DATABASE_PASSWORD_STABLE }}
           VAULT_JWT_AUTH_PATH: ${{ github.event.repository.name }}-stable
           VAULT_KV_SECRET_MOUNT_POINT: stable
+
+      - name: Deploy Cronjob to send removal notifications and clean old data
+        uses: City-of-Helsinki/setup-cronjob-action@main
+        with:
+          name: send-reminders-and-clean-old-data-cronjob
+          image_repository: ghcr.io/city-of-helsinki/${{ github.event.repository.name }}
+          image_tag: ${{ github.sha }}
+          kubeconfig_raw: ${{ env.KUBECONFIG_RAW }}
+          target_namespace: ${{ secrets.K8S_NAMESPACE_STABLE }}
+          schedule: "15 0 * * *" # Daily at quarter past midnight
+          secret_name: "project-kuvaselaamo-secret"
+          command: "{/bin/sh}"
+          args: "{-c,cd /app && python manage.py send_removal_notifications && python manage.py clean_unused_data && python manage.py clearsessions}"
+          max_duration: 900 # 15 minutes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+# [Unreleased]
+
+### Fixed
+- When sending removal notifications via email, a 400 error from Mailgun is now interpreted so that the email 
+  address is invalid and the user is marked as having been sent the message. This allows the scheduled run to continue 
+  processing.
+
 # [2.5.0] 2021-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
-# [Unreleased]
+# [2.5.1] 2021-05-12
 
 ### Fixed
 - When sending removal notifications via email, a 400 error from Mailgun is now interpreted so that the email 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+# [2.5.0] 2021-05-05
+
+### Added
+- Management command which sends email notifications to users whose accounts are going to be removed soon.
+- Production environment scheduling for the notification and removal.
+- Automated tests for the scheduled commands using pytest.
+- Vault configuration in the workflows for handling secrets.
+- Automated browser tests which ensure that the main user flows are functioning.
+
+### Changed
+- The scheduled cleanup job now waits until 30 days after an email notification has been sent before deleting 
+  any user data.
+- Removed a dummy test which acted as a placeholder.
+- Moved some testing related dependencies from requirements.in to requirements-dev.in.
+  
 # [2.4.1] 2021-04-01
 
 ### Fixed


### PR DESCRIPTION
### Fixed
- When sending removal notifications via email, a 400 error from Mailgun is now interpreted so that the email 
  address is invalid and the user is marked as having been sent the message. This allows the scheduled run to continue 
  processing.