### PR TITLE
HEL-294 | Change development process to Gitflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous integration
 
 on:
   push:
-    branches: [master, develop]
+    branches: [master]
   pull_request:
 
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,7 +2,7 @@ name: Build & Staging & Accept
 on:
   push:
     branches:
-      - develop
+      - master
 
 env:
   CONTAINER_REGISTRY: ghcr.io


### PR DESCRIPTION
We are abandoning `develop` branch in favor of Gitflow (= everything is
done in `master`).

I changed the deployment configs to trigger from master branch from now on.