### PR TITLE
HEL-298 | Fix typo in default front page image url

### DIFF
--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -72,7 +72,7 @@ def front_page_url(collection):
     record_count = collection.records.count() if collection else 0
 
     if not record_count:
-        img_url = '/static/hkm/img/front_page_default.jpg'
+        img_url = '/static/hkm/img/front_page_default_image.jpg'
     else:
         records = collection.records.all()
         random_index = randrange(record_count)


### PR DESCRIPTION
When there are no "show on front page" collections, as was the case in
production a while ago, the app shows a default image. For some reason
we had a typo in the image's url and we noticed it only in production
after the frontpage collections were removed via a scheduled.

I fixed the typo, so now the default image works in case there is a
similar issue in production.