### PR TITLE
Fix | image_type translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+# [2.7.2] 2021-08-24
+
+### Fixed
+- Added a type check for getting translation for `image_type`.
+
 # [2.7.1] 2021-08-16
 
 ### Changed

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -37,7 +37,7 @@ def record_detail(record):
     measures = record.get('rawData').get('measurements', [])
 
     for data in format:
-        if type(data) is dict:
+        if isinstance(data, dict):
             translated.append(data.get('translated'))
 
     array_fields['photographer'] = ", ".join(photographer) if photographer else ""

--- a/hkm/templatetags/hkm_tags.py
+++ b/hkm/templatetags/hkm_tags.py
@@ -26,6 +26,7 @@ def finna_image(img_id):
 def finna_default_image_url(img_id):
     return FINNA.get_image_url(img_id)
 
+
 @register.filter
 def record_detail(record):
     array_fields = {}
@@ -35,13 +36,15 @@ def record_detail(record):
     format = record.get('rawData').get('format', [])
     measures = record.get('rawData').get('measurements', [])
 
-    for type in format:
-        translated.append(type.get('translated'))
+    for data in format:
+        if type(data) is dict:
+            translated.append(data.get('translated'))
 
     array_fields['photographer'] = ", ".join(photographer) if photographer else ""
     array_fields['image_types'] = ', '.join(translated) if translated else ""
     array_fields['measures'] = ', '.join(measures) if measures else ""
     return array_fields
+
 
 @register.filter
 def display_images(collection):
@@ -66,6 +69,7 @@ def localized_decimal(value, arg=-1):
     formatted_value = floatformat(value, arg)
     return force_unicode(formats.localize(Decimal(formatted_value), use_l10n=True))
 
+
 @register.filter
 def front_page_url(collection):
     img_url = ""
@@ -79,6 +83,7 @@ def front_page_url(collection):
         img_url = records[random_index].get_preview_image_absolute_url()
 
     return img_url
+
 
 @register.filter
 def showcase_collections(showcase):


### PR DESCRIPTION
For some reason `data` under `format` is returning a string instead of a `dict`. I need to contact Finna to make sure if this is a bug or not. For now I just added a type check to fix application from crashing.

Viewing a single image will throw error on test + production: [test here](https://helsinkikuvia.fi/search/details/?image_id=hkm.HKMS000005:km0000lh18)
Error fixed on [PR env](https://kuvaselaamo-fix-image-type-translation-243.test.kuva.hel.ninja/search/details/?image_id=hkm.HKMS000005:km0000lh18)