### PR TITLE
Updated psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ protobuf==3.19.3
     #   google-api-core
     #   google-cloud-storage
     #   googleapis-common-protos
-psycopg2==2.8.6
+psycopg2==2.9.3
     # via -r requirements.in
 pyasn1==0.4.8
     # via


### PR DESCRIPTION
HEL-311. Updated psycopg2 to v.2.9.3 to fix issues on Mac OS platform.