### PR TITLE
fix: matomo cookieless tracking

### DIFF
--- a/hkm/static/hkm/js/cookie-consent.js
+++ b/hkm/static/hkm/js/cookie-consent.js
@@ -10,20 +10,9 @@
     $rejectBtn = $("#consent_reject"),
     $consentLink = $("#cookie-consent-link");
 
-  // always require on load
-  _paq.push(["requireCookieConsent"]);
-  _paq.push(["requireConsent"]);
-
-  // if rejected
-  if (cookie && cookie === "0") {
-    _paq.push(["forgetCookieConsentGiven"]);
-    _paq.push(["forgetConsentGiven"]);
-  }
-
   // if accepted
   if (cookie && cookie === "1") {
-    _paq.push(["rememberConsentGiven"]);
-    _paq.push(["rememberCookieConsentGiven"]);
+    _paq.push(['setCookieConsentGiven']);
   }
 
   if (!cookie) {
@@ -43,18 +32,16 @@
 
   $acceptBtn.on("click", function (e) {
     if (_paq) {
-      _paq.push(["rememberConsentGiven"]);
-      _paq.push(["rememberCookieConsentGiven"]);
-      $.cookie(cookieName, "1", { expires: 393 });
+      _paq.push(['setCookieConsentGiven']);
+      $.cookie(cookieName, "1", { expires: 393, path: '/' });
       $cookieConsentContainer.fadeOut();
     }
   });
 
   $rejectBtn.on("click", function (e) {
     if (_paq) {
-      _paq.push(["forgetConsentGiven"]);
-      _paq.push(["forgetCookieConsentGiven"]);
-      $.cookie(cookieName, "0", { expires: 393 });
+      _paq.push(['forgetCookieConsentGiven']);
+      $.cookie(cookieName, "0", { expires: 393, path: '/' });
       $cookieConsentContainer.fadeOut();
     }
   });

--- a/hkm/templates/hkm/base.html
+++ b/hkm/templates/hkm/base.html
@@ -201,10 +201,13 @@
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
+        _paq.push(["requireCookieConsent"]);
+
         (function() {
           var u="//webanalytics.digiaiiris.com/js/";
           _paq.push(['setTrackerUrl', u+'tracker.php']);
           _paq.push(['setSiteId', '1040']);
+
           var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
           g.async=true; g.src=u+'piwik.min.js'; s.parentNode.insertBefore(g,s);
         })();


### PR DESCRIPTION
Always require cookie consent but remove requirement for general tracking consent ("requireConsent"). Set cookie consent given if consent cookie is "1" and when cookie consent is clicked as accepted. Latter is probably unnecessary due to this not being a SPA. Cookies written to '/' to be effective throughout the site.