### PR TITLE
HEL-349 | Use Red Hat UBI Python image in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Exclude all
+*
+
+# Except the following:
+
+# Environment files
+!.env
+!.env.local
+!.env.development
+!.env.development.local
+!.env.test
+!.env.test.local
+
+# Subdirectories
+!.prod
+!browser-tests
+!hkm
+!kuvaselaamo
+
+# Frontend package configuration
+!package.json
+!package-lock.json
+
+# Backend package configuration
+!requirements.in
+!requirements.txt
+!requirements-dev.in
+!requirements-dev.txt
+!requirements-prod.in
+!requirements-prod.txt
+
+# Docker entrypoint (needed to run the container)
+!docker-entrypoint.sh
+
+# Management script (needed to run at least the "collectstatic" command)
+!manage.py
+
+# Miscellaneous
+!.coveragerc
+!gulpfile.js
+!k6LoadTests.js
+!setup.cfg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
     postgres:
         image: helsinkitest/postgis:9.6-2.5-alpine

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,12 @@ set -e
 echo "docker-entrypoint.sh here ..."
 
 if [ -z "$SKIP_DATABASE_CHECK" -o "$SKIP_DATABASE_CHECK" = "0" ]; then
-    wait-for-it.sh "${DATABASE_HOST}:${DATABASE_PORT-5432}"
+    until nc -z -v -w30 "${DATABASE_HOST}" "${DATABASE_PORT-5432}"
+    do
+        echo "Waiting for postgres database connection..."
+        sleep 1
+    done
+    echo "Database is up!"
 fi
 
 


### PR DESCRIPTION
## Description

### feat(docker): use red hat ubi9 python image, add .dockerignore file

also remove deprecated version number from docker-compose.yml:
"the attribute `version` is obsolete, it will be ignored, please remove
it to avoid potential confusion"

refs HEL-349

## Tickets

[HEL-349](https://helsinkisolutionoffice.atlassian.net/browse/HEL-349)

[HEL-349]: https://helsinkisolutionoffice.atlassian.net/browse/HEL-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ