### PR TITLE
HEL-351 | Update PostgreSQL to v13.13 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     postgres:
-        image: helsinkitest/postgis:9.6-2.5-alpine
+        image: public.ecr.aws/docker/library/postgres:13.13-alpine
         restart: on-failure
         environment:
             POSTGRES_USER: kuvaselaamo


### PR DESCRIPTION
## Description

### feat: upgrade postgres to v13.13 in docker-compose.yml

The PostgreSQL version used by the production database
psql-hel-platta-prod-001 is currently v13.12, so upgrading the
PostgreSQL version in docker-compose.yml to the nearest available
minor version i.e. v13.13.

Using Amazon ECR Public Registry as the Docker image source instead of
Docker Hub as the latter's rate limits were changed during summer 2024
and have been causing problems as of late.

refs HEL-351

## Tickets

[HEL-351](https://helsinkisolutionoffice.atlassian.net/browse/HEL-351)

[HEL-351]: https://helsinkisolutionoffice.atlassian.net/browse/HEL-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ